### PR TITLE
GIRAPH-864: Fixed compilation problem

### DIFF
--- a/giraph-rexster/giraph-rexster-io/pom.xml
+++ b/giraph-rexster/giraph-rexster-io/pom.xml
@@ -175,7 +175,7 @@ under the License.
       <artifactId>giraph-kibble</artifactId>
       <version>${project.version}</version>
       <scope>system</scope>
-      <systemPath>${top.dir}/giraph-rexster/giraph-kibble/target/giraph-kibble-${project.version}.jar</systemPath>
+      <systemPath>${top.dir}/giraph-rexster/giraph-kibble/target/giraph-kibble-${project.version}-jar-with-dependencies.jar</systemPath>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
As reported https://issues.apache.org/jira/browse/GIRAPH-864 , compiling does not work right now. There is a small problem with file  giraph-rexster/giraph-rexster-io/pom.xml. The following fix makes it work.
