### PR TITLE
[GIRAPH-1125] Memory estimation mechanism for more efficient OOC execution

### DIFF
--- a/giraph-core/pom.xml
+++ b/giraph-core/pom.xml
@@ -503,6 +503,10 @@ under the License.
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math</artifactId>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency>

--- a/giraph-core/src/main/java/org/apache/giraph/comm/NetworkMetrics.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/NetworkMetrics.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.giraph.comm;
+
+/**
+ * Interface for providing network statistics, such as bytes received etc.
+ */
+public interface NetworkMetrics {
+  /**
+   * Returns bytes received in current superstep
+   * @return Number of bytes.
+   */
+  long getBytesReceivedPerSuperstep();
+
+  /**
+   * Resets the counter for bytes received per superstep.
+   * This will be called by the component that defines
+   * when a superstep is done.
+   */
+  void resetBytesReceivedPerSuperstep();
+
+  /**
+   * Returns aggregate bytes received.
+   * @return Number of bytes
+   */
+  long getBytesReceived();
+}

--- a/giraph-core/src/main/java/org/apache/giraph/comm/ServerData.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/ServerData.java
@@ -131,11 +131,13 @@ public class ServerData<I extends WritableComparable,
    * Constructor.
    *
    * @param service Service worker
+   * @param workerServer Worker server
    * @param conf Configuration
    * @param context Mapper context
    */
   public ServerData(
       CentralizedServiceWorker<I, V, E> service,
+      WorkerServer workerServer,
       ImmutableClassesGiraphConfiguration<I, V, E> conf,
       Mapper<?, ?, ?, ?>.Context context) {
     this.serviceWorker = service;
@@ -147,7 +149,7 @@ public class ServerData<I extends WritableComparable,
     PartitionStore<I, V, E> inMemoryPartitionStore =
         new SimplePartitionStore<I, V, E>(conf, context);
     if (GiraphConstants.USE_OUT_OF_CORE_GRAPH.get(conf)) {
-      oocEngine = new OutOfCoreEngine(conf, service);
+      oocEngine = new OutOfCoreEngine(conf, service, workerServer);
       partitionStore =
           new DiskBackedPartitionStore<I, V, E>(inMemoryPartitionStore,
               conf, context, oocEngine);

--- a/giraph-core/src/main/java/org/apache/giraph/comm/WorkerServer.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/WorkerServer.java
@@ -35,7 +35,7 @@ import java.net.InetSocketAddress;
 @SuppressWarnings("rawtypes")
 public interface WorkerServer<I extends WritableComparable,
     V extends Writable, E extends Writable>
-    extends Closeable {
+    extends NetworkMetrics, Closeable {
   /**
    * Get server address
    *

--- a/giraph-core/src/main/java/org/apache/giraph/comm/flow_control/FlowControl.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/flow_control/FlowControl.java
@@ -83,11 +83,6 @@ public interface FlowControl {
   int calculateResponse(AckSignalFlag flag, int taskId);
 
   /**
-   * Shutdown the flow control policy
-   */
-  void shutdown();
-
-  /**
    * Log the status of the flow control
    */
   void logInfo();

--- a/giraph-core/src/main/java/org/apache/giraph/comm/flow_control/NoOpFlowControl.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/flow_control/NoOpFlowControl.java
@@ -66,8 +66,5 @@ public class NoOpFlowControl implements FlowControl {
   }
 
   @Override
-  public void shutdown() { }
-
-  @Override
   public void logInfo() { }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/comm/flow_control/StaticFlowControl.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/flow_control/StaticFlowControl.java
@@ -155,9 +155,6 @@ public class StaticFlowControl implements
   }
 
   @Override
-  public void shutdown() { }
-
-  @Override
   public void logInfo() {
     if (LOG.isInfoEnabled()) {
       LOG.info("logInfo: " + numWaitingThreads.get() + " threads waiting " +

--- a/giraph-core/src/main/java/org/apache/giraph/comm/netty/ByteCounterDelegate.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/netty/ByteCounterDelegate.java
@@ -44,8 +44,10 @@ public class ByteCounterDelegate implements ByteCounter {
       new DecimalFormat("#######.####");
   /** Class timer */
   private static final Time TIME = SystemTime.get();
-  /** All bytes ever processed */
+  /** Bytes processed during the most recent time interval */
   private final AtomicLong bytesProcessed = new AtomicLong();
+  /** Aggregate bytes per superstep */
+  private final AtomicLong bytesProcessedPerSuperstep = new AtomicLong();
   /** Total processed requests */
   private final AtomicLong processedRequests = new AtomicLong();
   /** Start time (for bandwidth calculation) */
@@ -99,6 +101,7 @@ public class ByteCounterDelegate implements ByteCounter {
   public int byteBookkeeper(ByteBuf buf) {
     int processedBytes = buf.readableBytes();
     bytesProcessed.addAndGet(processedBytes);
+    bytesProcessedPerSuperstep.addAndGet(processedBytes);
     processedBytesHist.update(processedBytes);
     processedRequests.incrementAndGet();
     processedRequestsMeter.mark();
@@ -124,6 +127,21 @@ public class ByteCounterDelegate implements ByteCounter {
   public void resetAll() {
     resetBytes();
     resetStartMsecs();
+  }
+
+  /**
+   * Returns bytes processed per superstep.
+   * @return Number of bytes.
+   */
+  public long getBytesProcessedPerSuperstep() {
+    return bytesProcessedPerSuperstep.get();
+  }
+
+  /**
+   * Set bytes processed per superstep to 0.
+   */
+  public void resetBytesProcessedPerSuperstep() {
+    bytesProcessedPerSuperstep.set(0);
   }
 
   public long getBytesProcessed() {

--- a/giraph-core/src/main/java/org/apache/giraph/comm/netty/InboundByteCounter.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/netty/InboundByteCounter.java
@@ -53,6 +53,21 @@ public class InboundByteCounter extends ChannelInboundHandlerAdapter implements
   }
 
   /**
+   * Returns bytes received per superstep.
+   * @return Number of bytes.
+   */
+  public long getBytesReceivedPerSuperstep() {
+    return delegate.getBytesProcessedPerSuperstep();
+  }
+
+  /**
+   * Set bytes received per superstep to 0.
+   */
+  public void resetBytesReceivedPerSuperstep() {
+    delegate.resetBytesProcessedPerSuperstep();
+  }
+
+  /**
    * @return Mbytes received / sec in the current interval
    */
   public double getMbytesPerSecReceived() {

--- a/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyClient.java
@@ -237,7 +237,7 @@ public class NettyClient {
     if (limitNumberOfOpenRequests) {
       flowControl = new StaticFlowControl(conf, this);
     } else if (limitOpenRequestsPerWorker) {
-      flowControl = new CreditBasedFlowControl(conf, this);
+      flowControl = new CreditBasedFlowControl(conf, this, exceptionHandler);
     } else {
       flowControl = new NoOpFlowControl(this);
     }
@@ -644,7 +644,6 @@ public class NettyClient {
     if (LOG.isInfoEnabled()) {
       LOG.info("stop: Halting netty client");
     }
-    flowControl.shutdown();
     // Close connections asynchronously, in a Netty-approved
     // way, without cleaning up thread pools until all channels
     // in addressChannelMap are closed (success or failure)

--- a/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyServer.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyServer.java
@@ -71,7 +71,6 @@ public class NettyServer {
   /** Default maximum thread pool size */
   public static final int MAXIMUM_THREAD_POOL_SIZE_DEFAULT = 32;
 
-
 /*if_not[HADOOP_NON_SECURE]*/
   /** Used to authenticate with netty clients */
   public static final AttributeKey<SaslNettyServer>
@@ -127,6 +126,7 @@ public class NettyServer {
   private final String handlerToUseExecutionGroup;
   /** Handles all uncaught exceptions in netty threads */
   private final Thread.UncaughtExceptionHandler exceptionHandler;
+
 
   /**
    * Constructor for creating the server
@@ -215,6 +215,14 @@ public class NettyServer {
     this.saslServerHandlerFactory = saslServerHandlerFactory;
   }
 /*end[HADOOP_NON_SECURE]*/
+
+  /**
+   * Returns a handle on the in-bound byte counter.
+   * @return The {@link InboundByteCounter} object for this server.
+   */
+  public InboundByteCounter getInByteCounter() {
+    return inByteCounter;
+  }
 
   /**
    * Start the server with the appropriate port

--- a/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyWorkerServer.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyWorkerServer.java
@@ -74,7 +74,7 @@ public class NettyWorkerServer<I extends WritableComparable,
     this.context = context;
 
     serverData =
-        new ServerData<I, V, E>(service, conf, context);
+        new ServerData<I, V, E>(service, this, conf, context);
 
     nettyServer = new NettyServer(conf,
         new WorkerRequestServerHandler.Factory<I, V, E>(serverData),
@@ -110,5 +110,20 @@ public class NettyWorkerServer<I extends WritableComparable,
   @Override
   public void setFlowControl(FlowControl flowControl) {
     nettyServer.setFlowControl(flowControl);
+  }
+
+  @Override
+  public long getBytesReceivedPerSuperstep() {
+    return nettyServer.getInByteCounter().getBytesReceivedPerSuperstep();
+  }
+
+  @Override
+  public void resetBytesReceivedPerSuperstep() {
+    nettyServer.getInByteCounter().resetBytesReceivedPerSuperstep();
+  }
+
+  @Override
+  public long getBytesReceived() {
+    return nettyServer.getInByteCounter().getBytesReceived();
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -75,8 +75,8 @@ import org.apache.giraph.master.MasterCompute;
 import org.apache.giraph.master.MasterObserver;
 import org.apache.giraph.ooc.persistence.OutOfCoreDataAccessor;
 import org.apache.giraph.ooc.persistence.LocalDiskDataAccessor;
+import org.apache.giraph.ooc.policy.MemoryEstimatorOracle;
 import org.apache.giraph.ooc.policy.OutOfCoreOracle;
-import org.apache.giraph.ooc.policy.ThresholdBasedOracle;
 import org.apache.giraph.partition.GraphPartitionerFactory;
 import org.apache.giraph.partition.HashPartitionerFactory;
 import org.apache.giraph.partition.Partition;
@@ -986,7 +986,7 @@ public interface GiraphConstants {
    */
   ClassConfOption<OutOfCoreOracle> OUT_OF_CORE_ORACLE =
       ClassConfOption.create("giraph.outOfCoreOracle",
-          ThresholdBasedOracle.class, OutOfCoreOracle.class,
+          MemoryEstimatorOracle.class, OutOfCoreOracle.class,
           "Out-of-core oracle that is to be used for adaptive out-of-core " +
               "engine");
 

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/data/MetaPartitionManager.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/data/MetaPartitionManager.java
@@ -526,8 +526,8 @@ public class MetaPartitionManager {
     meta = perThreadPartitionDictionary.get(threadId).lookup(
         ProcessingState.PROCESSED,
         StorageState.IN_MEM,
-        StorageState.ON_DISK,
-        null);
+        null,
+        StorageState.ON_DISK);
     if (meta != null) {
       return meta.getPartitionId();
     }
@@ -535,18 +535,17 @@ public class MetaPartitionManager {
     meta = perThreadPartitionDictionary.get(threadId).lookup(
         ProcessingState.PROCESSED,
         StorageState.ON_DISK,
-        StorageState.IN_MEM,
-        null);
+        null,
+        StorageState.IN_MEM);
     if (meta != null) {
       return meta.getPartitionId();
     }
 
-    // Forth, look for a processed partition entirely on disk
     meta = perThreadPartitionDictionary.get(threadId).lookup(
         ProcessingState.PROCESSED,
         StorageState.ON_DISK,
-        StorageState.ON_DISK,
-        null);
+        null,
+        StorageState.ON_DISK);
     if (meta != null) {
       return meta.getPartitionId();
     }

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/persistence/LocalDiskDataAccessor.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/persistence/LocalDiskDataAccessor.java
@@ -94,12 +94,11 @@ public class LocalDiskDataAccessor implements OutOfCoreDataAccessor {
     int ptr = 0;
     String jobId = conf.getJobId();
     for (String path : userPaths) {
-      File file = new File(path);
-      if (!file.exists()) {
-        checkState(file.mkdirs(), "LocalDiskDataAccessor: cannot create " +
-            "directory " + file.getAbsolutePath());
-      }
-      basePaths[ptr] = path + "/" + jobId;
+      String jobDirectory = path + "/" + jobId;
+      File file = new File(jobDirectory);
+      checkState(file.mkdirs(), "LocalDiskDataAccessor: cannot create " +
+          "directory " + file.getAbsolutePath());
+      basePaths[ptr] = jobDirectory + "/";
       ptr++;
     }
     final int diskBufferSize = OOC_DISK_BUFFER_SIZE.get(conf);
@@ -112,7 +111,7 @@ public class LocalDiskDataAccessor implements OutOfCoreDataAccessor {
   @Override
   public void shutdown() {
     for (String path : basePaths) {
-      File file = new File(path).getParentFile();
+      File file = new File(path);
       for (String subFileName : file.list()) {
         File subFile = new File(file.getPath(), subFileName);
         checkState(subFile.delete(), "shutdown: cannot delete file %s",

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/policy/FixedPartitionsOracle.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/policy/FixedPartitionsOracle.java
@@ -145,5 +145,6 @@ public class FixedPartitionsOracle implements OutOfCoreOracle {
   public void gcCompleted(GarbageCollectionNotificationInfo gcInfo) { }
 
   @Override
-  public void shutdown() { }
+  public void startIteration() {
+  }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/policy/MemoryEstimatorOracle.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/policy/MemoryEstimatorOracle.java
@@ -1,0 +1,834 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.giraph.ooc.policy;
+
+import com.sun.management.GarbageCollectionNotificationInfo;
+import org.apache.commons.math.stat.regression.OLSMultipleLinearRegression;
+import org.apache.giraph.comm.NetworkMetrics;
+import org.apache.giraph.conf.FloatConfOption;
+import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
+import org.apache.giraph.conf.LongConfOption;
+import org.apache.giraph.edge.AbstractEdgeStore;
+import org.apache.giraph.ooc.OutOfCoreEngine;
+import org.apache.giraph.ooc.command.IOCommand;
+import org.apache.giraph.ooc.command.LoadPartitionIOCommand;
+import org.apache.giraph.ooc.command.WaitIOCommand;
+import org.apache.giraph.worker.EdgeInputSplitsCallable;
+import org.apache.giraph.worker.VertexInputSplitsCallable;
+import org.apache.giraph.worker.WorkerProgress;
+import org.apache.log4j.Logger;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Implementation of {@link OutOfCoreOracle} that uses a linear regression model
+ * to estimate actual memory usage based on the current state of computation.
+ * The model takes into consideration 5 parameters:
+ *
+ * y = c0 + c1*x1 + c2*x2 + c3*x3 + c4*x4 + c5*x5
+ *
+ * y: memory usage
+ * x1: edges loaded
+ * x2: vertices loaded
+ * x3: vertices processed
+ * x4: bytes received due to messages
+ * x5: bytes loaded/stored from/to disk due to OOC.
+ *
+ */
+public class MemoryEstimatorOracle implements OutOfCoreOracle {
+  /** Memory check interval in msec */
+  public static final LongConfOption CHECK_MEMORY_INTERVAL =
+    new LongConfOption("giraph.garbageEstimator.checkMemoryInterval", 1000,
+      "The interval where memory checker thread wakes up and " +
+        "monitors memory footprint (in milliseconds)");
+  /** If mem-usage is above this threshold and no Full GC has been called,
+   * we call it manually. */
+  public static final FloatConfOption MANUAL_GC_MEMORY_PRESSURE =
+    new FloatConfOption("giraph.garbageEstimator.manualGCPressure", 0.95f, "");
+  /** Used to detect a high memory pressure situation */
+  public static final FloatConfOption GC_MINIMUM_RECLAIM_FRACTION =
+    new FloatConfOption("giraph.garbageEstimator.gcReclaimFraction", 0.05f, "");
+  /** If mem-usage is above this threshold, active threads are set to 0 */
+  public static final FloatConfOption AM_HIGH_THRESHOLD =
+    new FloatConfOption("giraph.amHighThreshold", 0.95f, "");
+  /** If mem-usage is below this threshold, active threads are set to max */
+  public static final FloatConfOption AM_LOW_THRESHOLD =
+    new FloatConfOption("giraph.amLowThreshold", 0.90f, "");
+  /** If mem-usage is above this threshold, creid is set to 0 */
+  public static final FloatConfOption CREDIT_HIGH_THRESHOLD =
+    new FloatConfOption("giraph.creditHighThreshold", 0.95f, "");
+  /** If mem-usage is below this threshold, credit is set to max */
+  public static final FloatConfOption CREDIT_LOW_THRESHOLD =
+    new FloatConfOption("giraph.creditLowThreshold", 0.90f, "");
+  /** OOC starts if mem-usage is above this treshold */
+  public static final FloatConfOption OOC_THRESHOLD =
+    new FloatConfOption("giraph.oocThreshold", 0.90f, "");
+
+  /** Logger */
+  private static final Logger LOG =
+    Logger.getLogger(MemoryEstimatorOracle.class);
+
+  /** Cached value for {@link #MANUAL_GC_MEMORY_PRESSURE} */
+  private final float manualGCMemoryPressure;
+  /** Cached value for {@link #GC_MINIMUM_RECLAIM_FRACTION} */
+  private final float gcReclaimFraction;
+  /** Cached value for {@link #AM_HIGH_THRESHOLD} */
+  private final float amHighThreshold;
+  /** Cached value for {@link #AM_LOW_THRESHOLD} */
+  private final float amLowThreshold;
+  /** Cached value for {@link #CREDIT_HIGH_THRESHOLD} */
+  private final float creditHighThreshold;
+  /** Cached value for {@link #CREDIT_LOW_THRESHOLD} */
+  private final float creditLowThreshold;
+  /** Cached value for {@link #OOC_THRESHOLD} */
+  private final float oocThreshold;
+
+  /** Reference to running OOC engine */
+  private final OutOfCoreEngine oocEngine;
+  /** Memory estimator instance */
+  private final MemoryEstimator memoryEstimator;
+  /** Keeps track of the number of bytes stored/loaded by OOC */
+  private final AtomicLong oocBytesInjected = new AtomicLong(0);
+  /** How many bytes to offload */
+  private final AtomicLong numBytesToOffload = new AtomicLong(0);
+  /** Current state of the OOC */
+  private volatile State state = State.STABLE;
+  /** Timestamp of the last major GC */
+  private volatile long lastMajorGCTime = 0;
+
+  /**
+   * Different states the OOC can be in.
+   */
+  private enum State {
+    /** No offloading */
+    STABLE,
+    /** Current offloading */
+    OFFLOADING,
+  }
+
+  /**
+   * Constructor.
+   * @param conf Configuration
+   * @param oocEngine OOC engine.:w
+   *
+   */
+  public MemoryEstimatorOracle(ImmutableClassesGiraphConfiguration conf,
+                               final OutOfCoreEngine oocEngine) {
+    this.oocEngine = oocEngine;
+    this.memoryEstimator = new MemoryEstimator(this.oocBytesInjected,
+      oocEngine.getNetworkMetrics());
+
+    this.manualGCMemoryPressure = MANUAL_GC_MEMORY_PRESSURE.get(conf);
+    this.gcReclaimFraction = GC_MINIMUM_RECLAIM_FRACTION.get(conf);
+    this.amHighThreshold = AM_HIGH_THRESHOLD.get(conf);
+    this.amLowThreshold = AM_LOW_THRESHOLD.get(conf);
+    this.creditHighThreshold = CREDIT_HIGH_THRESHOLD.get(conf);
+    this.creditLowThreshold = CREDIT_LOW_THRESHOLD.get(conf);
+    this.oocThreshold = OOC_THRESHOLD.get(conf);
+
+    final long checkMemoryInterval = CHECK_MEMORY_INTERVAL.get(conf);
+
+    Thread thread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        while (true) {
+          long oldGenUsageEstimate = memoryEstimator.getUsageEstimate();
+          MemoryUsage usage = getOldGenUsed();
+          if (oldGenUsageEstimate > 0) {
+            updateRates(oldGenUsageEstimate, usage.getMax());
+          } else {
+            long time = System.currentTimeMillis();
+            if (time - lastMajorGCTime >= 10000) {
+              double used = (double) usage.getUsed() / usage.getMax();
+              if (used > manualGCMemoryPressure) {
+                if (LOG.isInfoEnabled()) {
+                  LOG.info(
+                    "High memory pressure with no full GC from the JVM. " +
+                      "Calling GC manually. Used fraction of old-gen is " +
+                      String.format("%.2f", used) + ".");
+                }
+                System.gc();
+                time = System.currentTimeMillis() - time;
+                usage = getOldGenUsed();
+                used = (double) usage.getUsed() / usage.getMax();
+                if (LOG.isInfoEnabled()) {
+                  LOG.info("Manual GC done. It took " +
+                    String.format("%.2f", time / 1000.0) +
+                    " seconds. Used fraction of old-gen is " +
+                    String.format("%.2f", used) + ".");
+                }
+              }
+            }
+          }
+          try {
+            Thread.sleep(checkMemoryInterval);
+          } catch (InterruptedException e) {
+            LOG.warn("run: exception occurred!", e);
+            return;
+          }
+        }
+      }
+    });
+    thread.setUncaughtExceptionHandler(oocEngine.getServiceWorker()
+      .getGraphTaskManager().createUncaughtExceptionHandler());
+    thread.setName("ooc-memory-checker");
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  /**
+   * Resets all the counters used in the memory estimation. This is called at
+   * the beginning of a new superstep.
+   * <p>
+   * The number of vertices to compute in the next superstep gets reset in
+   * {@link org.apache.giraph.graph.GraphTaskManager#processGraphPartitions}
+   * right before {@link PartitionStore#startIteration()} gets called.
+   */
+  @Override
+  public void startIteration() {
+    oocBytesInjected.set(0);
+    memoryEstimator.clear();
+    memoryEstimator.setCurrentSuperstep(oocEngine.getSuperstep());
+    oocEngine.updateRequestsCreditFraction(1);
+    oocEngine.updateActiveThreadsFraction(1);
+  }
+
+
+  @Override
+  public IOAction[] getNextIOActions() {
+    if (state == State.OFFLOADING) {
+      return new IOAction[]{
+        IOAction.STORE_MESSAGES_AND_BUFFERS, IOAction.STORE_PARTITION};
+    }
+    long oldGenUsage = memoryEstimator.getUsageEstimate();
+    MemoryUsage usage = getOldGenUsed();
+    if (oldGenUsage > 0) {
+      double usageEstimate = (double) oldGenUsage / usage.getMax();
+      if (usageEstimate > oocThreshold) {
+        return new IOAction[]{
+          IOAction.STORE_MESSAGES_AND_BUFFERS,
+          IOAction.STORE_PARTITION};
+      } else {
+        return new IOAction[]{IOAction.LOAD_PARTITION};
+      }
+    } else {
+      return new IOAction[]{IOAction.LOAD_PARTITION};
+    }
+  }
+
+  @Override
+  public boolean approve(IOCommand command) {
+    return true;
+  }
+
+  @Override
+  public void commandCompleted(IOCommand command) {
+    // long oocBytesBefore = OOC_BYTES_INJECTED.get();
+    if (command instanceof LoadPartitionIOCommand) {
+      oocBytesInjected.getAndAdd(command.bytesTransferred());
+      if (state == State.OFFLOADING) {
+        numBytesToOffload.getAndAdd(command.bytesTransferred());
+      }
+    } else if (!(command instanceof WaitIOCommand)) {
+      oocBytesInjected.getAndAdd(0 - command.bytesTransferred());
+      if (state == State.OFFLOADING) {
+        numBytesToOffload.getAndAdd(0 - command.bytesTransferred());
+      }
+    }
+
+    if (state == State.OFFLOADING && numBytesToOffload.get() <= 0) {
+      numBytesToOffload.set(0);
+      state = State.STABLE;
+      updateRates(-1, 1);
+    }
+  }
+
+  /**
+   * When a new GC has completed, we can get an accurate measurement of the
+   * memory usage. We use this to update the linear regression model.
+   *
+   * @param gcInfo GC information
+   */
+  @Override
+  public synchronized void gcCompleted(
+    GarbageCollectionNotificationInfo gcInfo) {
+    String action = gcInfo.getGcAction().toLowerCase();
+    String cause = gcInfo.getGcCause().toLowerCase();
+    if (action.contains("major") &&
+      (cause.contains("ergo") || cause.contains("system"))) {
+      lastMajorGCTime = System.currentTimeMillis();
+      MemoryUsage before = null;
+      MemoryUsage after = null;
+
+      for (Map.Entry<String, MemoryUsage> entry :
+        gcInfo.getGcInfo().getMemoryUsageBeforeGc().entrySet()) {
+        String poolName = entry.getKey();
+        if (poolName.toLowerCase().contains("old")) {
+          before = entry.getValue();
+          after = gcInfo.getGcInfo().getMemoryUsageAfterGc().get(poolName);
+          break;
+        }
+      }
+      if (after == null) {
+        throw new IllegalStateException("Missing Memory Usage After GC info");
+      }
+      if (before == null) {
+        throw new IllegalStateException("Missing Memory Usage Before GC info");
+      }
+
+      // Compare the estimation with the actual value
+      long usedMemoryEstimate = memoryEstimator.getUsageEstimate();
+      long usedMemoryReal = after.getUsed();
+      if (usedMemoryEstimate >= 0) {
+        if (LOG.isInfoEnabled()) {
+          LOG.info("gcCompleted: estimate=" + usedMemoryEstimate + " real=" +
+            usedMemoryReal + " error=" +
+            ((double) Math.abs(usedMemoryEstimate - usedMemoryReal) /
+              usedMemoryReal * 100));
+        }
+      }
+
+      // Number of edges loaded so far (if in input superstep)
+      long edgesLoaded = oocEngine.getSuperstep() >= 0 ? 0 :
+        EdgeInputSplitsCallable.getTotalEdgesLoadedMeter().count();
+      // Number of vertices loaded so far (if in input superstep)
+      long verticesLoaded = oocEngine.getSuperstep() >= 0 ? 0 :
+        VertexInputSplitsCallable.getTotalVerticesLoadedMeter().count();
+      // Number of vertices computed (if either in compute or store phase)
+      long verticesComputed = WorkerProgress.get().getVerticesComputed() +
+        WorkerProgress.get().getVerticesStored() +
+        AbstractEdgeStore.PROGRESS_COUNTER.getProgress();
+      // Number of bytes received
+      long receivedBytes =
+        oocEngine.getNetworkMetrics().getBytesReceivedPerSuperstep();
+      // Number of OOC bytes
+      long oocBytes = oocBytesInjected.get();
+
+      memoryEstimator.addRecord(getOldGenUsed().getUsed(), edgesLoaded,
+        verticesLoaded, verticesComputed, receivedBytes, oocBytes);
+
+      long garbage = before.getUsed() - after.getUsed();
+      long maxMem = after.getMax();
+      long memUsed = after.getUsed();
+      boolean isTight = (maxMem - memUsed) < 2 * gcReclaimFraction * maxMem &&
+        garbage < gcReclaimFraction * maxMem;
+      boolean predictionExist = memoryEstimator.getUsageEstimate() > 0;
+      if (isTight && !predictionExist) {
+        if (LOG.isInfoEnabled()) {
+          LOG.info("gcCompleted: garbage=" + garbage + " memUsed=" +
+            memUsed + " maxMem=" + maxMem);
+        }
+        numBytesToOffload.set((long) (2 * gcReclaimFraction * maxMem) -
+          (maxMem - memUsed));
+        if (LOG.isInfoEnabled()) {
+          LOG.info("gcCompleted: tight memory usage. Starting to offload " +
+            "until " + numBytesToOffload.get() + " bytes are offloaded");
+        }
+        state = State.OFFLOADING;
+        updateRates(1, 1);
+      }
+    }
+  }
+
+  /**
+   * Given an estimate for the current memory usage and the maximum available
+   * memory, it updates the active threads and flow control credit in the
+   * OOC engine.
+   *
+   * @param usageEstimateMem Estimate of memory usage.
+   * @param maxMemory Maximum memory.
+   */
+  private void updateRates(long usageEstimateMem, long maxMemory) {
+    double usageEstimate = (double) usageEstimateMem / maxMemory;
+    if (usageEstimate > 0) {
+      if (usageEstimate >= amHighThreshold) {
+        oocEngine.updateActiveThreadsFraction(0);
+      } else if (usageEstimate < amLowThreshold) {
+        oocEngine.updateActiveThreadsFraction(1);
+      } else {
+        oocEngine.updateActiveThreadsFraction(1 -
+          (usageEstimate - amLowThreshold) /
+            (amHighThreshold - amLowThreshold));
+      }
+
+      if (usageEstimate >= creditHighThreshold) {
+        oocEngine.updateRequestsCreditFraction(0);
+      } else if (usageEstimate < creditLowThreshold) {
+        oocEngine.updateRequestsCreditFraction(1);
+      } else {
+        oocEngine.updateRequestsCreditFraction(1 -
+          (usageEstimate - creditLowThreshold) /
+            (creditHighThreshold - creditLowThreshold));
+      }
+    } else {
+      oocEngine.updateActiveThreadsFraction(1);
+      oocEngine.updateRequestsCreditFraction(1);
+    }
+  }
+
+  /**
+   * Returns statistics about the old gen pool.
+   * @return {@link MemoryUsage}.
+   */
+  private MemoryUsage getOldGenUsed() {
+    List<MemoryPoolMXBean> memoryPoolList =
+      ManagementFactory.getMemoryPoolMXBeans();
+    for (MemoryPoolMXBean pool : memoryPoolList) {
+      String normalName = pool.getName().toLowerCase();
+      if (normalName.contains("old") || normalName.contains("tenured")) {
+        return pool.getUsage();
+      }
+    }
+    throw new IllegalStateException("Bad Memory Pool");
+  }
+
+  /**
+   * Maintains statistics about the current state and progress of the
+   * computation and produces estimates of memory usage using a technique
+   * based on linear regression.
+   *
+   * Upon a GC events, it gets updated with the most recent statistics through
+   * the {@link #addRecord} method.
+   */
+  private static class MemoryEstimator {
+    /** Stores the (x1,x2,...,x5) arrays of data samples, one for each sample */
+    private Vector<double[]> dataSamples = new Vector<>();
+    /** Stores the y memory usage dataSamples, one for each sample */
+    private Vector<Double> memorySamples = new Vector<>();
+    /** Stores the coefficients computed by the linear regression model */
+    private double[] coefficient = new double[6];
+    /** Stores the column indices that can be used in the regression model */
+    private Vector<Integer> validColumnIndices = new Vector<>();
+    /** Potentially out-of-range coefficient values */
+    private double[] extreme = new double[6];
+    /** Indicates whether current coefficients can be used for estimation */
+    private boolean isValid = false;
+    /** Implementation of linear regression */
+    private OLSMultipleLinearRegression mlr = new OLSMultipleLinearRegression();
+    /** Used to synchronize access to the data samples */
+    private Lock lock = new ReentrantLock();
+    /** The estimation method depends on the current superstep. */
+    private long currentSuperstep = -1;
+    /** The estimation method depends on the bytes injected. */
+    private final AtomicLong oocBytesInjected;
+    /** Provides network statistics */
+    private final NetworkMetrics networkMetrics;
+
+    /**
+     * Constructor
+     * @param oocBytesInjected Reference to {@link AtomiLong} object maintaining
+     *                         the number of OOC bytes stored.
+     * @param networkMetrics Interface to get network stats.
+     */
+    public MemoryEstimator(AtomicLong oocBytesInjected,
+                           NetworkMetrics networkMetrics) {
+      this.oocBytesInjected = oocBytesInjected;
+      this.networkMetrics = networkMetrics;
+    }
+
+
+    /**
+     * Clear data structure (called from single threaded program).
+     */
+    public void clear() {
+      dataSamples.clear();
+      memorySamples.clear();
+      isValid = false;
+    }
+
+    public void setCurrentSuperstep(long superstep) {
+      this.currentSuperstep = superstep;
+    }
+
+    /**
+     * Given the current state of computation (i.e. current edges loaded,
+     * vertices computed etc) and the current model (i.e. the regression
+     * coefficient), it returns a prediction about the memory usage in bytes.
+     *
+     * @return Memory estimate in bytes.
+     */
+    public long getUsageEstimate() {
+      long usage = -1;
+      lock.lock();
+      try {
+        if (isValid) {
+          // Number of edges loaded so far (if in input superstep)
+          long edgesLoaded = currentSuperstep >= 0 ? 0 :
+            EdgeInputSplitsCallable.getTotalEdgesLoadedMeter().count();
+          // Number of vertices loaded so far (if in input superstep)
+          long verticesLoaded = currentSuperstep >= 0 ? 0 :
+            VertexInputSplitsCallable.getTotalVerticesLoadedMeter().count();
+          // Number of vertices computed (if either in compute or store phase)
+          long verticesComputed = WorkerProgress.get().getVerticesComputed() +
+            WorkerProgress.get().getVerticesStored() +
+            AbstractEdgeStore.PROGRESS_COUNTER.getProgress();
+          // Number of bytes received
+          long receivedBytes = networkMetrics.getBytesReceivedPerSuperstep();
+          // Number of OOC bytes
+          long oocBytes = this.oocBytesInjected.get();
+
+          usage = (long) (edgesLoaded * coefficient[0] +
+            verticesLoaded * coefficient[1] +
+            verticesComputed * coefficient[2] +
+            receivedBytes * coefficient[3] +
+            oocBytes * coefficient[4] +
+            coefficient[5]);
+        }
+      } finally {
+        lock.unlock();
+      }
+      return usage;
+    }
+
+    /**
+     * Updates the linear regression model with a new data point.
+     *
+     * @param memUsed Current real value of memory usage.
+     * @param edges Number of edges loaded.
+     * @param vertices Number of vertices loaded.
+     * @param verticesProcessed Number of vertices processed.
+     * @param bytesReceived Number of bytes received.
+     * @param oocBytesInjected Number of bytes stored/loaded due to OOC.
+     */
+    public void addRecord(long memUsed, long edges, long vertices,
+                          long verticesProcessed,
+                          long bytesReceived, long oocBytesInjected) {
+      checkState(memUsed > 0, "Memory Usage cannot be negative");
+      if (dataSamples.size() > 0) {
+        double[] last = dataSamples.get(dataSamples.size() - 1);
+        if (edges == last[0] && vertices == last[1] &&
+          verticesProcessed == last[2] && bytesReceived == last[3] &&
+          oocBytesInjected == last[4]) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(
+              "addRecord: avoiding to add the same entry as the last one!");
+          }
+          return;
+        }
+      }
+      dataSamples.add(new double[] {edges, vertices, verticesProcessed,
+        bytesReceived, oocBytesInjected});
+      memorySamples.add((double) memUsed);
+
+      // Weed out the columns that are all zero
+      validColumnIndices.clear();
+      for (int i = 0; i < 5; ++i) {
+        boolean validIndex = false;
+        // Check if there is a non-zero entry in the column
+        for (double[] value : dataSamples) {
+          if (value[i] != 0) {
+            validIndex = true;
+            break;
+          }
+        }
+        if (validIndex) {
+          // check if all entries are not equal to each other
+          double firstValue = -1;
+          boolean allEqual = true;
+          for (double[] value : dataSamples) {
+            if (firstValue == -1) {
+              firstValue = value[i];
+            } else {
+              if (Math.abs((value[i] - firstValue) / firstValue) > 0.01) {
+                allEqual = false;
+                break;
+              }
+            }
+          }
+          validIndex = !allEqual;
+          if (validIndex) {
+            // Check if the column has linear dependency with another column
+            for (int col = i + 1; col < 5; ++col) {
+              if (isLinearDependence(dataSamples, i, col)) {
+                validIndex = false;
+                break;
+              }
+            }
+          }
+        }
+
+        if (validIndex) {
+          validColumnIndices.add(i);
+        }
+      }
+
+      // If we filtered out columns in the previous step, we are going to run
+      // the regression without those columns.
+
+      // Create the coefficient table
+      boolean setIsValid = false;
+      lock.lock();
+      try {
+        if (validColumnIndices.size() >= 1 &&
+          dataSamples.size() >= validColumnIndices.size() + 1) {
+
+          double[][] xValues = new double[dataSamples.size()][];
+          double[] yValues = new double[memorySamples.size()];
+          fillXMatrix(dataSamples, validColumnIndices, xValues);
+          copyVectorToArray(memorySamples, yValues);
+          mlr.newSampleData(yValues, xValues);
+          calculateRegression(coefficient, validColumnIndices, mlr);
+
+          // After the computation of the regression, some coefficients may have
+          // values outside the valid value range. In this case, we set the
+          // coefficient to the minimum or maximum value allowed, and re-run the
+          // regression.
+          boolean changed;
+          extreme[3] = -1;
+          extreme[4] = -1;
+          do {
+            changed = refineCoefficient(4, 1, 2, xValues, yValues);
+            changed |= refineCoefficient(3, 0, 2, xValues, yValues);
+          } while (changed);
+          if (extreme[3] != -1) {
+            coefficient[3] = extreme[3];
+          }
+          if (extreme[4] != -1) {
+            coefficient[4] = extreme[4];
+          }
+          setIsValid = true;
+          return; // the finally-block will execute before return
+        }
+        // CHECKSTYLE: stop IllegalCatch
+      } catch (Exception e) {
+        // CHECKSTYLE: resume IllegalCatch
+        LOG.warn("addRecord: exception occurred!", e);
+      } finally {
+        // This inner try-finally block is necessary to ensure that the
+        // lock is always released.
+        try {
+          isValid = setIsValid;
+          printStats();
+        } finally {
+          lock.unlock();
+        }
+      }
+    }
+
+    /**
+     * Certain coefficients need to be within a specific range. For instance,
+     * If the coefficient is not in this range, we set it to the closest bound
+     * and re-run the linear regression.
+     *
+     * @param coefIndex Coefficient index
+     * @param lowerBound Lower bound
+     * @param upperBound Upper bound
+     * @param xValues double[][] matrix with data samples
+     * @param yValues double[] matrix with y samples
+     * @return True if coefficients were out-of-range
+     * @throws Exception
+     */
+    private boolean refineCoefficient(int coefIndex, double lowerBound,
+      double upperBound, double[][] xValues, double[] yValues)
+      throws Exception {
+
+      boolean result = false;
+      if (coefficient[coefIndex] < lowerBound ||
+        coefficient[coefIndex] > upperBound) {
+
+        double value;
+        if (coefficient[coefIndex] < lowerBound) {
+          value = lowerBound;
+        } else {
+          value = upperBound;
+        }
+        int ptr = -1;
+        if (validColumnIndices.size() >= 1 &&
+          validColumnIndices.get(validColumnIndices.size() - 1) == coefIndex) {
+          ptr = validColumnIndices.size() - 1;
+        } else if (validColumnIndices.size() >= 2 &&
+          validColumnIndices.get(validColumnIndices.size() - 2) == coefIndex) {
+          ptr = validColumnIndices.size() - 2;
+        }
+        if (ptr != -1) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("addRecord: coefficient at index " + coefIndex +
+              " is wrong in the regression, setting it to " + value);
+          }
+          // remove from valid column
+          validColumnIndices.remove(ptr);
+          // re-create the X matrix
+          fillXMatrix(dataSamples, validColumnIndices, xValues);
+          // adjust Y values
+          for (int i = 0; i < memorySamples.size(); ++i) {
+            yValues[i] -= value * dataSamples.get(i)[coefIndex];
+          }
+          // save new coefficient value in intermediate array
+          extreme[coefIndex] = value;
+          // re-run regression
+          mlr.newSampleData(yValues, xValues);
+          calculateRegression(coefficient, validColumnIndices, mlr);
+          result = true;
+        } else {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(
+              "addRecord: coefficient was not in the regression, " +
+                "setting it to the lower bound");
+          }
+          result = false;
+        }
+        coefficient[coefIndex] = value;
+      }
+      return result;
+    }
+
+    /**
+     * Calculates the regression.
+     * @param coefficient Array of coefficients
+     * @param validColumnIndices List of valid columns
+     * @param mlr {@link OLSMultipleLinearRegression} instance.
+     * @throws Exception
+     */
+    private static void calculateRegression(double[] coefficient,
+      Vector<Integer> validColumnIndices, OLSMultipleLinearRegression mlr)
+      throws Exception {
+
+      if (coefficient.length != validColumnIndices.size()) {
+        throw new Exception("There are " + coefficient.length +
+          " coefficients, but " + validColumnIndices.size() +
+          " valid columns in the regression");
+      }
+
+      double[] beta = mlr.estimateRegressionParameters();
+      for (int i = 0; i < coefficient.length; ++i) {
+        coefficient[i] = 0;
+      }
+      for (int i = 0; i < validColumnIndices.size(); ++i) {
+        coefficient[validColumnIndices.get(i)] = beta[i];
+      }
+      coefficient[5] = beta[validColumnIndices.size()];
+    }
+
+    /**
+     * Copys the values from a Vector to an array.
+     * @param source Source vector of values
+     * @param target Target array.
+     */
+    private static void copyVectorToArray(Vector<Double> source,
+                                          double[] target) {
+      for (int i = 0; i < source.size(); ++i) {
+        target[i] = source.get(i);
+      }
+    }
+
+    /**
+     * Copies values from a Vector of double[] to a double[][]. Takes into
+     * consideration the list of valid column indices.
+     * @param sourceValues Source Vector of double[]
+     * @param validColumnIndices Valid column indices
+     * @param xValues Target double[][] matrix.
+     */
+    private static void fillXMatrix(Vector<double[]> sourceValues,
+      Vector<Integer> validColumnIndices, double[][] xValues) {
+
+      for (int i = 0; i < sourceValues.size(); ++i) {
+        xValues[i] = new double[validColumnIndices.size() + 1];
+        for (int j = 0; j < validColumnIndices.size(); ++j) {
+          xValues[i][j] = sourceValues.get(i)[validColumnIndices.get(j)];
+        }
+        xValues[i][validColumnIndices.size()] = 1;
+      }
+    }
+
+    /**
+     * Utility function that checks whether two doubles are equals given an
+     * accuracy tolerance.
+     *
+     * @param val1 First value
+     * @param val2 Second value
+     * @return True if within a threshold
+     */
+    private static boolean equal(double val1, double val2) {
+      return Math.abs(val1 - val2) < 0.01;
+    }
+
+    /**
+     * Utility function that checks if two columns have linear dependence.
+     *
+     * @param values Matrix in the form of a Vector of double[] values.
+     * @param col1 First column index
+     * @param col2 Second column index
+     * @return True if there is linear dependence.
+     */
+    private static boolean isLinearDependence(Vector<double[]> values,
+                                              int col1, int col2) {
+
+      Vector<Double> factor = new Vector<>();
+      for (double[] value : values) {
+        double val1 = value[col1];
+        double val2 = value[col2];
+        if (equal(val1, 0)) {
+          if (equal(val2, 0)) {
+            continue;
+          } else {
+            return false;
+          }
+        }
+        if (equal(val2, 0)) {
+          return false;
+        }
+        factor.add(val1 / val2);
+      }
+
+      if (factor.size() < 2) {
+        return true;
+      }
+      double firstVal = factor.get(0);
+      for (int i = 1; i < factor.size(); ++i) {
+        if (!equal((factor.get(i) - firstVal) / firstVal, 0)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /**
+     * Prints statistics about the regression model.
+     */
+    private void printStats() {
+      if (LOG.isDebugEnabled()) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(
+          "\nEDGES\t\tVERTICES\t\tV_PROC\t\tRECEIVED\t\tOOC\t\tMEM_USED\n");
+        for (int i = 0; i < dataSamples.size(); ++i) {
+          for (int j = 0; j < dataSamples.get(i).length; ++j) {
+            sb.append(String.format("%.2f\t\t", dataSamples.get(i)[j]));
+          }
+          sb.append(memorySamples.get(i));
+          sb.append("\n");
+        }
+        sb.append("COEFFICIENT:\n");
+        for (int i = 0; i < coefficient.length; ++i) {
+          sb.append(String.format("%.2f\t\t", coefficient[i]));
+        }
+        sb.append("\n");
+        LOG.debug("printStats: isValid=" + isValid + sb.toString());
+      }
+    }
+  }
+}

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/policy/MemoryEstimatorOracle.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/policy/MemoryEstimatorOracle.java
@@ -64,30 +64,46 @@ public class MemoryEstimatorOracle implements OutOfCoreOracle {
   /** Memory check interval in msec */
   public static final LongConfOption CHECK_MEMORY_INTERVAL =
     new LongConfOption("giraph.garbageEstimator.checkMemoryInterval", 1000,
-      "The interval where memory checker thread wakes up and " +
-        "monitors memory footprint (in milliseconds)");
-  /** If mem-usage is above this threshold and no Full GC has been called,
-   * we call it manually. */
+        "The interval where memory checker thread wakes up and " +
+            "monitors memory footprint (in milliseconds)");
+  /**
+   * If mem-usage is above this threshold and no Full GC has been called,
+   * we call it manually
+   */
   public static final FloatConfOption MANUAL_GC_MEMORY_PRESSURE =
-    new FloatConfOption("giraph.garbageEstimator.manualGCPressure", 0.95f, "");
+    new FloatConfOption("giraph.garbageEstimator.manualGCPressure", 0.95f,
+        "The threshold above which GC is called manually if Full GC has not " +
+            "happened in a while");
   /** Used to detect a high memory pressure situation */
   public static final FloatConfOption GC_MINIMUM_RECLAIM_FRACTION =
-    new FloatConfOption("giraph.garbageEstimator.gcReclaimFraction", 0.05f, "");
+    new FloatConfOption("giraph.garbageEstimator.gcReclaimFraction", 0.05f,
+        "Minimum percentage of memory we expect to be reclaimed after a Full " +
+            "GC. If less than this amount is reclaimed, it is sage to say " +
+            "we are in a high memory situation and the estimation mechanism " +
+            "has not recognized it yet!");
   /** If mem-usage is above this threshold, active threads are set to 0 */
   public static final FloatConfOption AM_HIGH_THRESHOLD =
-    new FloatConfOption("giraph.amHighThreshold", 0.95f, "");
+    new FloatConfOption("giraph.amHighThreshold", 0.95f,
+        "If mem-usage is above this threshold, all active threads " +
+            "(compute/input) are paused.");
   /** If mem-usage is below this threshold, active threads are set to max */
   public static final FloatConfOption AM_LOW_THRESHOLD =
-    new FloatConfOption("giraph.amLowThreshold", 0.90f, "");
-  /** If mem-usage is above this threshold, creid is set to 0 */
+    new FloatConfOption("giraph.amLowThreshold", 0.90f,
+        "If mem-usage is below this threshold, all active threads " +
+            "(compute/input) are running.");
+  /** If mem-usage is above this threshold, credit is set to 0 */
   public static final FloatConfOption CREDIT_HIGH_THRESHOLD =
-    new FloatConfOption("giraph.creditHighThreshold", 0.95f, "");
+    new FloatConfOption("giraph.creditHighThreshold", 0.95f,
+        "If mem-usage is above this threshold, credit is set to 0");
   /** If mem-usage is below this threshold, credit is set to max */
   public static final FloatConfOption CREDIT_LOW_THRESHOLD =
-    new FloatConfOption("giraph.creditLowThreshold", 0.90f, "");
-  /** OOC starts if mem-usage is above this treshold */
+    new FloatConfOption("giraph.creditLowThreshold", 0.90f,
+        "If mem-usage is below this threshold, credit is set to max");
+  /** OOC starts if mem-usage is above this threshold */
   public static final FloatConfOption OOC_THRESHOLD =
-    new FloatConfOption("giraph.oocThreshold", 0.90f, "");
+    new FloatConfOption("giraph.oocThreshold", 0.90f,
+        "If mem-usage is above this threshold, out of core threads starts " +
+            "writing data to disk");
 
   /** Logger */
   private static final Logger LOG =
@@ -207,7 +223,9 @@ public class MemoryEstimatorOracle implements OutOfCoreOracle {
    * <p>
    * The number of vertices to compute in the next superstep gets reset in
    * {@link org.apache.giraph.graph.GraphTaskManager#processGraphPartitions}
-   * right before {@link PartitionStore#startIteration()} gets called.
+   * right before
+   * {@link org.apache.giraph.partition.PartitionStore#startIteration()} gets
+   * called.
    */
   @Override
   public void startIteration() {
@@ -248,7 +266,6 @@ public class MemoryEstimatorOracle implements OutOfCoreOracle {
 
   @Override
   public void commandCompleted(IOCommand command) {
-    // long oocBytesBefore = OOC_BYTES_INJECTED.get();
     if (command instanceof LoadPartitionIOCommand) {
       oocBytesInjected.getAndAdd(command.bytesTransferred());
       if (state == State.OFFLOADING) {
@@ -441,8 +458,8 @@ public class MemoryEstimatorOracle implements OutOfCoreOracle {
 
     /**
      * Constructor
-     * @param oocBytesInjected Reference to {@link AtomiLong} object maintaining
-     *                         the number of OOC bytes stored.
+     * @param oocBytesInjected Reference to {@link AtomicLong} object
+     *                         maintaining the number of OOC bytes stored.
      * @param networkMetrics Interface to get network stats.
      */
     public MemoryEstimator(AtomicLong oocBytesInjected,
@@ -725,7 +742,7 @@ public class MemoryEstimatorOracle implements OutOfCoreOracle {
     }
 
     /**
-     * Copys the values from a Vector to an array.
+     * Copies the values from a Vector to an array.
      * @param source Source vector of values
      * @param target Target array.
      */

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/policy/OutOfCoreOracle.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/policy/OutOfCoreOracle.java
@@ -128,8 +128,7 @@ public interface OutOfCoreOracle {
   void gcCompleted(GarbageCollectionNotificationInfo gcInfo);
 
   /**
-   * Shut down the out-of-core oracle. Necessary specifically for cases where
-   * out-of-core oracle is using additional monitoring threads.
+   * Called at the beginning of a superstep.
    */
-  void shutdown();
+  void startIteration();
 }

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/policy/SimpleGCMonitoringOracle.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/policy/SimpleGCMonitoringOracle.java
@@ -141,6 +141,10 @@ public class SimpleGCMonitoringOracle implements OutOfCoreOracle {
     lastGCObservation = observation;
   }
 
+  @Override
+  public void startIteration() {
+  }
+
   /**
    * Get the current data injection rate to memory based on the commands ran
    * in the history (retrieved from statistics collector), and outstanding
@@ -273,9 +277,6 @@ public class SimpleGCMonitoringOracle implements OutOfCoreOracle {
   public void commandCompleted(IOCommand command) {
     commandOccurrences.get(command.getType()).getAndDecrement();
   }
-
-  @Override
-  public void shutdown() { }
 
   /** Helper class to record memory status after GC calls */
   private class GCObservation {

--- a/giraph-core/src/main/java/org/apache/giraph/utils/ProgressCounter.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/ProgressCounter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.giraph.utils;
+
+/**
+ * Used to keep track of a metric.
+ */
+public class ProgressCounter {
+  /**
+   * Current count.
+   */
+  private long count = 0;
+
+  /**
+   * Returns counter value.
+   * @return value
+   */
+  public long getValue() {
+    return count;
+  }
+
+  /**
+   * Increments counter
+   */
+  public void inc() {
+    count++;
+  }
+}

--- a/giraph-core/src/main/java/org/apache/giraph/utils/ThreadLocalProgressCounter.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/ThreadLocalProgressCounter.java
@@ -32,7 +32,7 @@ public class ThreadLocalProgressCounter extends ThreadLocal<ProgressCounter> {
 
   /**
    * Initializes a new counter, adds it to the list of counters
-   * and and returns it.
+   * and returns it.
    * @return Progress counter.
    */
   @Override
@@ -65,4 +65,3 @@ public class ThreadLocalProgressCounter extends ThreadLocal<ProgressCounter> {
     counters.clear();
   }
 }
-

--- a/giraph-core/src/main/java/org/apache/giraph/utils/ThreadLocalProgressCounter.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/ThreadLocalProgressCounter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.giraph.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Makes a list of {@link ProgressCounter} accessible through
+ * a {@link ThreadLocal}.
+ */
+public class ThreadLocalProgressCounter extends ThreadLocal<ProgressCounter> {
+  /**
+   * List of counters.
+   */
+  private final List<ProgressCounter> counters = new ArrayList<>();
+
+  /**
+   * Initializes a new counter, adds it to the list of counters
+   * and and returns it.
+   * @return Progress counter.
+   */
+  @Override
+  protected ProgressCounter initialValue() {
+    ProgressCounter threadCounter = new ProgressCounter();
+    synchronized (counters) {
+      counters.add(threadCounter);
+    }
+    return threadCounter;
+  }
+
+  /**
+   * Sums the progress of all counters.
+   * @return Sum of all counters
+   */
+  public long getProgress() {
+    long progress = 0;
+    synchronized (counters) {
+      for (ProgressCounter entry : counters) {
+        progress += entry.getValue();
+      }
+    }
+    return progress;
+  }
+
+  /**
+   * Removes all counters.
+   */
+  public void reset() {
+    counters.clear();
+  }
+}
+

--- a/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
@@ -714,6 +714,7 @@ else[HADOOP_NON_SECURE]*/
     workerInfoList.clear();
     workerInfoList = addressesAndPartitions.getWorkerInfos();
     masterInfo = addressesAndPartitions.getMasterInfo();
+    workerServer.resetBytesReceivedPerSuperstep();
 
     if (LOG.isInfoEnabled()) {
       LOG.info("startSuperstep: " + masterInfo);

--- a/giraph-core/src/test/java/org/apache/giraph/partition/TestPartitionStores.java
+++ b/giraph-core/src/test/java/org/apache/giraph/partition/TestPartitionStores.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.giraph.bsp.BspService;
 import org.apache.giraph.bsp.CentralizedServiceWorker;
 import org.apache.giraph.comm.ServerData;
+import org.apache.giraph.comm.WorkerServer;
 import org.apache.giraph.comm.netty.NettyClient;
 import org.apache.giraph.conf.GiraphConfiguration;
 import org.apache.giraph.conf.GiraphConstants;
@@ -162,13 +163,14 @@ public class TestPartitionStores {
 
     CentralizedServiceWorker<IntWritable, IntWritable, NullWritable>
       serviceWorker = Mockito.mock(CentralizedServiceWorker.class);
+    WorkerServer workerServer = Mockito.mock(WorkerServer.class);
     Mockito.when(serviceWorker.getSuperstep()).thenReturn(
         BspService.INPUT_SUPERSTEP);
     GraphTaskManager<IntWritable, IntWritable, NullWritable>
         graphTaskManager = Mockito.mock(GraphTaskManager.class);
     Mockito.when(serviceWorker.getGraphTaskManager()).thenReturn(graphTaskManager);
     ServerData<IntWritable, IntWritable, NullWritable>
-        serverData = new ServerData<>(serviceWorker, conf, context);
+        serverData = new ServerData<>(serviceWorker, workerServer, conf, context);
     Mockito.when(serviceWorker.getServerData()).thenReturn(serverData);
 
     DiskBackedPartitionStore<IntWritable, IntWritable, NullWritable>
@@ -191,13 +193,14 @@ public class TestPartitionStores {
 
     CentralizedServiceWorker<IntWritable, IntWritable, NullWritable>
     serviceWorker = Mockito.mock(CentralizedServiceWorker.class);
+    WorkerServer workerServer = Mockito.mock(WorkerServer.class);
     Mockito.when(serviceWorker.getSuperstep()).thenReturn(
         BspService.INPUT_SUPERSTEP);
     GraphTaskManager<IntWritable, IntWritable, NullWritable>
         graphTaskManager = Mockito.mock(GraphTaskManager.class);
     Mockito.when(serviceWorker.getGraphTaskManager()).thenReturn(graphTaskManager);
     ServerData<IntWritable, IntWritable, NullWritable>
-        serverData = new ServerData<>(serviceWorker, conf, context);
+        serverData = new ServerData<>(serviceWorker, workerServer, conf, context);
     Mockito.when(serviceWorker.getServerData()).thenReturn(serverData);
 
     DiskBackedPartitionStore<IntWritable, IntWritable, NullWritable>
@@ -308,6 +311,7 @@ public class TestPartitionStores {
 
     CentralizedServiceWorker<IntWritable, IntWritable, NullWritable>
     serviceWorker = Mockito.mock(CentralizedServiceWorker.class);
+    WorkerServer workerServer = Mockito.mock(WorkerServer.class);
 
     Mockito.when(serviceWorker.getSuperstep()).thenReturn(
         BspService.INPUT_SUPERSTEP);
@@ -315,7 +319,7 @@ public class TestPartitionStores {
         graphTaskManager = Mockito.mock(GraphTaskManager.class);
     Mockito.when(serviceWorker.getGraphTaskManager()).thenReturn(graphTaskManager);
     ServerData<IntWritable, IntWritable, NullWritable>
-        serverData = new ServerData<>(serviceWorker, conf, context);
+        serverData = new ServerData<>(serviceWorker, workerServer, conf, context);
     Mockito.when(serviceWorker.getServerData()).thenReturn(serverData);
 
     DiskBackedPartitionStore<IntWritable, IntWritable, NullWritable>

--- a/giraph-core/src/test/java/org/apache/giraph/utils/MockUtils.java
+++ b/giraph-core/src/test/java/org/apache/giraph/utils/MockUtils.java
@@ -21,6 +21,7 @@ package org.apache.giraph.utils;
 import org.apache.giraph.bsp.CentralizedServiceWorker;
 import org.apache.giraph.comm.ServerData;
 import org.apache.giraph.comm.WorkerClientRequestProcessor;
+import org.apache.giraph.comm.WorkerServer;
 import org.apache.giraph.comm.messages.ByteArrayMessagesPerVertexStore;
 import org.apache.giraph.conf.GiraphConfiguration;
 import org.apache.giraph.conf.GiraphConstants;
@@ -206,9 +207,10 @@ public class MockUtils {
         ByteArrayMessagesPerVertexStore.newFactory(serviceWorker, conf)
             .getClass());
 
+    WorkerServer workerServer = Mockito.mock(WorkerServer.class);
     ServerData<IntWritable, IntWritable, IntWritable> serverData =
       new ServerData<IntWritable, IntWritable, IntWritable>(
-          serviceWorker, conf, context);
+          serviceWorker, workerServer, conf, context);
     // Here we add a partition to simulate the case that there is one partition.
     serverData.getPartitionStore().addPartition(new SimplePartition());
     return serverData;

--- a/pom.xml
+++ b/pom.xml
@@ -1695,6 +1695,11 @@ under the License.
         <version>${dep.commons-lang3.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-math</artifactId>
+        <version>2.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.facebook.thirdparty.yourkit-api</groupId>
         <artifactId>yjp-controller-api-redist</artifactId>
         <version>${dep.yourkit-api.version}</version>


### PR DESCRIPTION
**Thanks to Dionysios Logothetis for helping a lot with this diff.**

The new out-of-core mechanism is designed with the adaptivity goal in mind, meaning that we wanted the out-of-core mechanism to kick in only when it is necessary. In other words, when the amount of data (graph, messages, and mutations) all fit in memory, we want to take advantage of the entire memory. And, when in a stage the memory is short, only enough (minimal) amount of data goes out of core (to disk). This ensures a good performance for the out-of-core mechanism.

To satisfy the adaptiveness goal, we need to know how much memory is used at each point of time. The default out-of-core mechanism (ThresholdBasedOracle) get memory information based on JVM's internal methods (Runtime's freeMemory()). This method is inaccurate (and pessimistic), meaning that it does not account for garbage data that has not been purged by GC. Using JVM's default methods, OOC behaves pessimistically and move data out of core even if it is not necessary. For instance,
consider the case where there are a lot of garbage on the heap, but GC has not happened for a while. In this case, the default OOC pushes data on disk and immediately after a major GC it brings back the data to memory. This causes inefficiency in the default out of core mechanism. If out-of-core is used, but the data can entirely fit in memory, the job goes out of core even though going out of core is not necessary.

To address this issue, we need to have a mechanism to more accurately know how much of heap is filled with non-garbage data. Consequently, we need to change the Oracle (OOC policy) to take advantage of a more accurate memory usage estimation.

In this diff, we introduce a mechanism to estimate the amount of memory used by non-garbage data on the heap at each point of time. This estimation is based on the fact that Giraph is a data-parallel system in its essence, meaning that several types of threads exist, each type doing the same computation on various data. More specifically, we have compute/input threads, communication (receiving) threads, and OOC-IO threads. In a normal uniform execution, each type of threads behave
similarly and contribute similarly to each other on the memory footprint (meaning that different compute threads contribute similarly to each other on the memory footprint). In the proposed approach, we use a measure of progress for each type of thread and use linear regression to estimate the amount of memory.

The measure of progress for compute threads is the total number of vertices they have collectively processed in a superstep at each point, the measure of progress for communication threads is the total number of bytes received by a worker up to each point, and the measure of progress for IO threads is the amount of data read/written to disk up to each point during a superstep. These measures are restarted at the beginning of each superstep. We use these measures at the point where full GC
happens (when we have the accurate estimation of non-garbage data on the heap) and devise the linear model of used memory. We then use the linear model to estimate the amount of memory at each time based on the above progress measures.