### PR TITLE
OutEdges & primitive types

### DIFF
--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/AbstractBlockFactory.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/AbstractBlockFactory.java
@@ -97,7 +97,7 @@ public abstract class AbstractBlockFactory<S> implements BlockFactory<S> {
       } else {
         TypeOps<?> edgeValueTypeOps =
             TypeOpsUtils.getTypeOpsOrNull(edgeValueClass);
-        if (edgeValueTypeOps != null) {
+        if (edgeValueTypeOps != null && idTypeOps != null) {
           GiraphConstants.VERTEX_EDGES_CLASS.set(
               conf, IdAndValueArrayEdges.class);
         }


### PR DESCRIPTION
Apps that had a primitive edge value but a non-primitive vertex ID would fail with an exception.

Test plan:
- mvn clean install
- internal snapshot tests
- internal unit tests
- tested with app that uses a double edge value and a non-primitive vertex ID.