### PR TITLE
GIRAPH-1133: Fix JobProgressTracker in OverrideExceptionHandler

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/graph/GraphTaskManager.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/GraphTaskManager.java
@@ -224,10 +224,10 @@ end[PURE_YARN]*/
     context.setStatus("setup: Beginning worker setup.");
     Configuration hadoopConf = context.getConfiguration();
     conf = new ImmutableClassesGiraphConfiguration<I, V, E>(hadoopConf);
+    initializeJobProgressTracker();
     // Setting the default handler for uncaught exceptions.
     Thread.setDefaultUncaughtExceptionHandler(createUncaughtExceptionHandler());
     setupMapperObservers();
-    initializeJobProgressTracker();
     // Write user's graph types (I,V,E,M) back to configuration parameters so
     // that they are set for quicker access later. These types are often
     // inferred from the Computation class used.


### PR DESCRIPTION
Summary: We create OverrideExceptionHandler before JobProgressTracker, so it can't report errors to command line.

Test Plan: Ran a job with exception caught by OverrideExceptionHandler before and after the change