### PR TITLE
GIRAPH-1134: Track number of input splits in command line

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/graph/JobProgressTrackerClientNoOp.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/JobProgressTrackerClientNoOp.java
@@ -18,6 +18,7 @@
 
 package org.apache.giraph.graph;
 
+import org.apache.giraph.master.MasterProgress;
 import org.apache.giraph.worker.WorkerProgress;
 
 /**
@@ -47,5 +48,9 @@ public class JobProgressTrackerClientNoOp implements JobProgressTrackerClient {
 
   @Override
   public void updateProgress(WorkerProgress workerProgress) {
+  }
+
+  @Override
+  public void updateMasterProgress(MasterProgress masterProgress) {
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
@@ -21,6 +21,7 @@ package org.apache.giraph.graph;
 import org.apache.giraph.conf.GiraphConfiguration;
 import org.apache.giraph.job.ClientThriftServer;
 import org.apache.giraph.job.JobProgressTracker;
+import org.apache.giraph.master.MasterProgress;
 import org.apache.giraph.worker.WorkerProgress;
 import org.apache.log4j.Logger;
 
@@ -148,6 +149,16 @@ public class RetryableJobProgressTrackerClient
       @Override
       public void run() {
         jobProgressTracker.updateProgress(workerProgress);
+      }
+    });
+  }
+
+  @Override
+  public void updateMasterProgress(final MasterProgress masterProgress) {
+    executeWithRetry(new Runnable() {
+      @Override
+      public void run() {
+        jobProgressTracker.updateMasterProgress(masterProgress);
       }
     });
   }

--- a/giraph-core/src/main/java/org/apache/giraph/job/JobProgressTracker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/job/JobProgressTracker.java
@@ -20,6 +20,8 @@ package org.apache.giraph.job;
 
 import com.facebook.swift.service.ThriftMethod;
 import com.facebook.swift.service.ThriftService;
+
+import org.apache.giraph.master.MasterProgress;
 import org.apache.giraph.worker.WorkerProgress;
 
 /**
@@ -64,5 +66,13 @@ public interface JobProgressTracker {
    */
   @ThriftMethod
   void updateProgress(WorkerProgress workerProgress);
+
+  /**
+   * Master should call this method to update its progress
+   *
+   * @param masterProgress Progress of the master
+   */
+  @ThriftMethod
+  void updateMasterProgress(MasterProgress masterProgress);
 }
 

--- a/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
@@ -659,24 +659,28 @@ public class BspServiceMaster<I extends WritableComparable,
 
   @Override
   public int createVertexInputSplits() {
-    // Short-circuit if there is no vertex input format
-    if (!getConfiguration().hasVertexInputFormat()) {
-      return 0;
+    int splits = 0;
+    if (getConfiguration().hasVertexInputFormat()) {
+      VertexInputFormat<I, V, E> vertexInputFormat =
+          getConfiguration().createWrappedVertexInputFormat();
+      splits = createInputSplits(vertexInputFormat, InputType.VERTEX);
     }
-    VertexInputFormat<I, V, E> vertexInputFormat =
-        getConfiguration().createWrappedVertexInputFormat();
-    return createInputSplits(vertexInputFormat, InputType.VERTEX);
+    MasterProgress.get().setVertexInputSplitCount(splits);
+    getJobProgressTracker().updateMasterProgress(MasterProgress.get());
+    return splits;
   }
 
   @Override
   public int createEdgeInputSplits() {
-    // Short-circuit if there is no edge input format
-    if (!getConfiguration().hasEdgeInputFormat()) {
-      return 0;
+    int splits = 0;
+    if (getConfiguration().hasEdgeInputFormat()) {
+      EdgeInputFormat<I, E> edgeInputFormat =
+          getConfiguration().createWrappedEdgeInputFormat();
+      splits = createInputSplits(edgeInputFormat, InputType.EDGE);
     }
-    EdgeInputFormat<I, E> edgeInputFormat =
-        getConfiguration().createWrappedEdgeInputFormat();
-    return createInputSplits(edgeInputFormat, InputType.EDGE);
+    MasterProgress.get().setEdgeInputSplitsCount(splits);
+    getJobProgressTracker().updateMasterProgress(MasterProgress.get());
+    return splits;
   }
 
   @Override

--- a/giraph-core/src/main/java/org/apache/giraph/master/MasterProgress.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/MasterProgress.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.giraph.master;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+/**
+ * Stores information about master progress
+ */
+@ThriftStruct
+public final class MasterProgress {
+  /** Singleton instance for everyone to use */
+  private static final MasterProgress INSTANCE = new MasterProgress();
+
+  /** How many vertex input splits were created */
+  private int vertexInputSplitCount = -1;
+  /** How many edge input splits were created */
+  private int edgeInputSplitCount = -1;
+
+  /**
+   * Public constructor for thrift to create us.
+   * Please use MasterProgress.get() to get the static instance.
+   */
+  public MasterProgress() {
+  }
+
+  /**
+   * Get singleton instance of MasterProgress.
+   *
+   * @return MasterProgress singleton instance
+   */
+  public static MasterProgress get() {
+    return INSTANCE;
+  }
+
+  @ThriftField(1)
+  public int getVertexInputSplitCount() {
+    return vertexInputSplitCount;
+  }
+
+  @ThriftField
+  public void setVertexInputSplitCount(int vertexInputSplitCount) {
+    this.vertexInputSplitCount = vertexInputSplitCount;
+  }
+
+  @ThriftField(2)
+  public int getEdgeInputSplitsCount() {
+    return edgeInputSplitCount;
+  }
+
+  @ThriftField
+  public void setEdgeInputSplitsCount(int edgeInputSplitCount) {
+    this.edgeInputSplitCount = edgeInputSplitCount;
+  }
+
+  /**
+   * Whether or not number of vertex input splits was set yet
+   *
+   * @return True iff it was set
+   */
+  public boolean vertexInputSplitsSet() {
+    return vertexInputSplitCount != -1;
+  }
+
+  /**
+   * Whether or not number of edge input splits was set yet
+   *
+   * @return True iff it was set
+   */
+  public boolean edgeInputSplitsSet() {
+    return edgeInputSplitCount != -1;
+  }
+}


### PR DESCRIPTION
Summary: The progress we track during input reports how much data have we read, but not how much data there is to read.

Test Plan: Now it prints something like:
 Loading data: 70046603 vertices loaded, 658 vertex input splits loaded (out of 659); 7122062703 edges loaded, 4 edge input splits loaded (out of 1322)