### PR TITLE
[GIRAPH-1137] Remove channel probing from Netty worker thread for credit-based flow…

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/comm/flow_control/CreditBasedFlowControl.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/flow_control/CreditBasedFlowControl.java
@@ -33,6 +33,7 @@ import org.apache.giraph.comm.requests.WritableRequest;
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
 import org.apache.giraph.conf.IntConfOption;
 import org.apache.giraph.utils.AdjustableSemaphore;
+import org.apache.giraph.utils.ThreadUtils;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayDeque;
@@ -208,7 +209,7 @@ public class CreditBasedFlowControl implements FlowControl {
     waitingRequestMsecs = WAITING_REQUEST_MSECS.get(conf);
 
     // Thread to handle/send resume signals when necessary
-    Thread resumeHandlerThread = new Thread(new Runnable() {
+    ThreadUtils.startThread(new Runnable() {
       @Override
       public void run() {
         while (true) {
@@ -230,14 +231,10 @@ public class CreditBasedFlowControl implements FlowControl {
           }
         }
       }
-    });
-    resumeHandlerThread.setUncaughtExceptionHandler(exceptionHandler);
-    resumeHandlerThread.setName("resume-sender");
-    resumeHandlerThread.setDaemon(true);
-    resumeHandlerThread.start();
+    }, "resume-sender", exceptionHandler);
 
     // Thread to handle/send cached requests
-    Thread cachedRequestHandlerThread = new Thread(new Runnable() {
+    ThreadUtils.startThread(new Runnable() {
       @Override
       public void run() {
         while (true) {
@@ -258,11 +255,7 @@ public class CreditBasedFlowControl implements FlowControl {
           }
         }
       }
-    });
-    cachedRequestHandlerThread.setUncaughtExceptionHandler(exceptionHandler);
-    cachedRequestHandlerThread.setName("cached-req-sender");
-    cachedRequestHandlerThread.setDaemon(true);
-    cachedRequestHandlerThread.start();
+    }, "cached-req-sender", exceptionHandler);
   }
 
   /**

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/policy/MemoryEstimatorOracle.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/policy/MemoryEstimatorOracle.java
@@ -29,6 +29,7 @@ import org.apache.giraph.ooc.OutOfCoreEngine;
 import org.apache.giraph.ooc.command.IOCommand;
 import org.apache.giraph.ooc.command.LoadPartitionIOCommand;
 import org.apache.giraph.ooc.command.WaitIOCommand;
+import org.apache.giraph.utils.ThreadUtils;
 import org.apache.giraph.worker.EdgeInputSplitsCallable;
 import org.apache.giraph.worker.VertexInputSplitsCallable;
 import org.apache.giraph.worker.WorkerProgress;
@@ -171,7 +172,7 @@ public class MemoryEstimatorOracle implements OutOfCoreOracle {
 
     final long checkMemoryInterval = CHECK_MEMORY_INTERVAL.get(conf);
 
-    Thread thread = new Thread(new Runnable() {
+    ThreadUtils.startThread(new Runnable() {
       @Override
       public void run() {
         while (true) {
@@ -211,12 +212,8 @@ public class MemoryEstimatorOracle implements OutOfCoreOracle {
           }
         }
       }
-    });
-    thread.setUncaughtExceptionHandler(oocEngine.getServiceWorker()
-      .getGraphTaskManager().createUncaughtExceptionHandler());
-    thread.setName("ooc-memory-checker");
-    thread.setDaemon(true);
-    thread.start();
+    }, "ooc-memory-checker", oocEngine.getServiceWorker().getGraphTaskManager()
+        .createUncaughtExceptionHandler());
   }
 
   /**

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/policy/ThresholdBasedOracle.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/policy/ThresholdBasedOracle.java
@@ -26,6 +26,7 @@ import org.apache.giraph.conf.LongConfOption;
 import org.apache.giraph.ooc.OutOfCoreEngine;
 import org.apache.giraph.ooc.command.IOCommand;
 import org.apache.giraph.utils.MemoryUtils;
+import org.apache.giraph.utils.ThreadUtils;
 import org.apache.log4j.Logger;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -170,7 +171,7 @@ public class ThresholdBasedOracle implements OutOfCoreOracle {
     this.oocEngine = oocEngine;
     this.lastMajorGCTime = 0;
 
-    final Thread thread = new Thread(new Runnable() {
+    ThreadUtils.startThread(new Runnable() {
       @Override
       public void run() {
         while (true) {
@@ -207,12 +208,8 @@ public class ThresholdBasedOracle implements OutOfCoreOracle {
           }
         }
       }
-    });
-    thread.setUncaughtExceptionHandler(oocEngine.getServiceWorker()
-        .getGraphTaskManager().createUncaughtExceptionHandler());
-    thread.setName("memory-checker");
-    thread.setDaemon(true);
-    thread.start();
+    }, "memory-checker", oocEngine.getServiceWorker().getGraphTaskManager().
+        createUncaughtExceptionHandler());
   }
 
   /**

--- a/giraph-core/src/main/java/org/apache/giraph/utils/ThreadUtils.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/ThreadUtils.java
@@ -106,6 +106,24 @@ public class ThreadUtils {
   }
 
   /**
+   * Start thread with specified name, runnable and exception handler, and make
+   * it daemon
+   *
+   * @param runnable Runnable to execute
+   * @param threadName Name of the thread
+   * @param handler Exception handler
+   * @return Thread
+   */
+  public static Thread startThread(Runnable runnable, String threadName,
+                                   Thread.UncaughtExceptionHandler handler) {
+    Thread thread = new Thread(runnable, threadName);
+    thread.setUncaughtExceptionHandler(handler);
+    thread.setDaemon(true);
+    thread.start();
+    return thread;
+  }
+
+  /**
    * Sleep for specified milliseconds, logging and ignoring interrupted
    * exceptions
    *


### PR DESCRIPTION
In credit-based flow-control, sometimes, client threads (one type of Netty worker threads used in Giraph) try to send requests to other workers. This is bad practice for Netty and can cause Netty to mark the execution as deadlock-prone (an example exception shown below). Client threads should only be responsible for sending ACK/NACK messages in response to requests, and they should do so by reuseing the channel from which they received the request. In the current implementation, client threads may try to send unsent/cached requests in credit-based flow control. Sending such requests should be delegated to other threads.

WARN 2017-03-08 06:06:22,104 [netty-client-worker-3] ....
io.netty.util.concurrent.BlockingOperationException: DefaultChannelPromise@2c455378(incomplete)
at io.netty.util.concurrent.DefaultPromise.checkDeadLock(DefaultPromise.java:383)
at io.netty.channel.DefaultChannelPromise.checkDeadLock(DefaultChannelPromise.java:157)
at io.netty.util.concurrent.DefaultPromise.await0(DefaultPromise.java:343)
at io.netty.util.concurrent.DefaultPromise.await(DefaultPromise.java:259)
at org.apache.giraph.utils.ProgressableUtils$ChannelFutureWaitable.waitFor(ProgressableUtils.java:461)
at org.apache.giraph.utils.ProgressableUtils.waitFor(ProgressableUtils.java:214)
at org.apache.giraph.utils.ProgressableUtils.waitForever(ProgressableUtils.java:180)
at org.apache.giraph.utils.ProgressableUtils.waitForever(ProgressableUtils.java:165)
at org.apache.giraph.utils.ProgressableUtils.awaitChannelFuture(ProgressableUtils.java:132)
at org.apache.giraph.comm.netty.NettyClient.getNextChannel(NettyClient.java:715)
at org.apache.giraph.comm.netty.NettyClient.writeRequestToChannel(NettyClient.java:799)
at org.apache.giraph.comm.netty.NettyClient.doSend(NettyClient.java:789)
at org.apache.giraph.comm.flow_control.CreditBasedFlowControl.trySendCachedRequests(CreditBasedFlowControl.java:515)
at org.apache.giraph.comm.flow_control.CreditBasedFlowControl.messageAckReceived(CreditBasedFlowControl.java:485)
at org.apache.giraph.comm.netty.NettyClient.messageReceived(NettyClient.java:840)
at org.apache.giraph.comm.netty.handler.ResponseClientHandler.channelRead(ResponseClientHandler.java:87)
at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:153)
at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
at org.apache.giraph.comm.netty.InboundByteCounter.channelRead(InboundByteCounter.java:89)
at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785)
at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:126)
at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:485)
at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:452)
at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:346)
at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101)
at java.lang.Thread.run(Thread.java:745)
