### PR TITLE
[GIRAPH-1138] Don't wrap exceptions from executor service

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/utils/ProgressableUtils.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/ProgressableUtils.java
@@ -270,8 +270,15 @@ public class ProgressableUtils {
           // Try to get result from the future
           result = entry.getValue().get(
               MSEC_TO_WAIT_ON_EACH_FUTURE, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | ExecutionException e) {
-          throw new IllegalStateException("Exception occurred", e);
+        } catch (InterruptedException e) {
+          throw new IllegalStateException("Interrupted", e);
+        } catch (ExecutionException e) {
+          // Execution exception wraps the actual cause
+          if (e.getCause() instanceof RuntimeException) {
+            throw (RuntimeException) e.getCause();
+          } else {
+            throw new IllegalStateException("Exception occurred", e.getCause());
+          }
         } catch (TimeoutException e) {
           // If result is not ready yet just keep waiting
           continue;


### PR DESCRIPTION
Summary: In ProgressableUtils.getResultsWithNCallables we wrap exceptions from underlying threads, making logs hard to read. We should re-throw original exception when possible.

Test Plan: Ran a job which fails in one of input threads before and after change, verified exception is clear now