### PR TITLE
[GIRAPH-1139] Fix resuming from checkpoint

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/bsp/BspService.java
+++ b/giraph-core/src/main/java/org/apache/giraph/bsp/BspService.java
@@ -188,12 +188,12 @@ public abstract class BspService<I extends WritableComparable,
   private long cachedApplicationAttempt = UNSET_APPLICATION_ATTEMPT;
   /** Job id, to ensure uniqueness */
   private final String jobId;
-  /** Task partition, to ensure uniqueness */
-  private final int taskPartition;
+  /** Task id, derived from partition and application attempt to ensure uniqueness */
+  private final int taskId;
   /** My hostname */
   private final String hostname;
-  /** Combination of hostname '_' partition (unique id) */
-  private final String hostnamePartitionId;
+  /** Combination of hostname '_' task (unique id) */
+  private final String hostnameTaskId;
   /** Graph partitioner */
   private final GraphPartitionerFactory<I, V, E> graphPartitionerFactory;
   /** Mapper that will do the graph computation */
@@ -231,8 +231,8 @@ public abstract class BspService<I extends WritableComparable,
     this.context = context;
     this.graphTaskManager = graphTaskManager;
     this.conf = graphTaskManager.getConf();
+
     this.jobId = conf.getJobId();
-    this.taskPartition = conf.getTaskPartition();
     this.restartedSuperstep = conf.getLong(
         GiraphConstants.RESTART_SUPERSTEP, UNSET_SUPERSTEP);
     try {
@@ -240,7 +240,6 @@ public abstract class BspService<I extends WritableComparable,
     } catch (UnknownHostException e) {
       throw new RuntimeException(e);
     }
-    this.hostnamePartitionId = hostname + "_" + getTaskPartition();
     this.graphPartitionerFactory = conf.createGraphPartitioner();
 
     basePath = ZooKeeperManager.getBasePath(conf) + BASE_DIR + "/" + jobId;
@@ -251,6 +250,8 @@ public abstract class BspService<I extends WritableComparable,
     inputSplitsAllDonePath = basePath + INPUT_SPLITS_ALL_DONE_NODE;
     applicationAttemptsPath = basePath + APPLICATION_ATTEMPTS_DIR;
     cleanedUpPath = basePath + CLEANED_UP_DIR;
+
+
 
     String restartJobId = RESTART_JOB_ID.get(conf);
 
@@ -272,7 +273,7 @@ public abstract class BspService<I extends WritableComparable,
     }
     if (LOG.isInfoEnabled()) {
       LOG.info("BspService: Connecting to ZooKeeper with job " + jobId +
-          ", " + getTaskPartition() + " on " + serverPortList);
+          ", " + getTaskId() + " on " + serverPortList);
     }
     try {
       this.zk = new ZooKeeperExt(serverPortList,
@@ -287,6 +288,9 @@ public abstract class BspService<I extends WritableComparable,
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+
+    this.taskId = (int)getApplicationAttempt() * conf.getMaxWorkers() + conf.getTaskPartition();
+    this.hostnameTaskId = hostname + "_" + getTaskId();
 
     //Trying to restart from the latest superstep
     if (restartJobId != null &&
@@ -529,12 +533,12 @@ public abstract class BspService<I extends WritableComparable,
     return hostname;
   }
 
-  public final String getHostnamePartitionId() {
-    return hostnamePartitionId;
+  public final String getHostnameTaskId() {
+    return hostnameTaskId;
   }
 
-  public final int getTaskPartition() {
-    return taskPartition;
+  public final int getTaskId() {
+    return taskId;
   }
 
   public final GraphTaskManager<I, V, E> getGraphTaskManager() {

--- a/giraph-core/src/main/java/org/apache/giraph/bsp/BspService.java
+++ b/giraph-core/src/main/java/org/apache/giraph/bsp/BspService.java
@@ -273,7 +273,7 @@ public abstract class BspService<I extends WritableComparable,
     }
     if (LOG.isInfoEnabled()) {
       LOG.info("BspService: Connecting to ZooKeeper with job " + jobId +
-          ", " + getTaskId() + " on " + serverPortList);
+          ", partition " + conf.getTaskPartition() + " on " + serverPortList);
     }
     try {
       this.zk = new ZooKeeperExt(serverPortList,

--- a/giraph-core/src/main/java/org/apache/giraph/bsp/BspService.java
+++ b/giraph-core/src/main/java/org/apache/giraph/bsp/BspService.java
@@ -188,7 +188,7 @@ public abstract class BspService<I extends WritableComparable,
   private long cachedApplicationAttempt = UNSET_APPLICATION_ATTEMPT;
   /** Job id, to ensure uniqueness */
   private final String jobId;
-  /** Task id, derived from partition and application attempt to ensure uniqueness */
+  /** Task id, from partition and application attempt to ensure uniqueness */
   private final int taskId;
   /** My hostname */
   private final String hostname;
@@ -289,7 +289,8 @@ public abstract class BspService<I extends WritableComparable,
       throw new RuntimeException(e);
     }
 
-    this.taskId = (int)getApplicationAttempt() * conf.getMaxWorkers() + conf.getTaskPartition();
+    this.taskId = (int) getApplicationAttempt() * conf.getMaxWorkers() +
+            conf.getTaskPartition();
     this.hostnameTaskId = hostname + "_" + getTaskId();
 
     //Trying to restart from the latest superstep

--- a/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
@@ -860,7 +860,7 @@ public class BspServiceMaster<I extends WritableComparable,
                   getGraphTaskManager().createUncaughtExceptionHandler());
           masterInfo.setInetSocketAddress(masterServer.getMyAddress(),
               masterServer.getLocalHostOrIp());
-          masterInfo.setTaskId(getTaskPartition());
+          masterInfo.setTaskId((int)getApplicationAttempt() * getConfiguration().getMaxWorkers() + getTaskPartition());
           masterClient =
               new NettyMasterClient(getContext(), getConfiguration(), this,
                   getGraphTaskManager().createUncaughtExceptionHandler());

--- a/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
@@ -1211,6 +1211,7 @@ public class BspServiceMaster<I extends WritableComparable,
     setApplicationAttempt(getApplicationAttempt() + 1);
     setCachedSuperstep(checkpoint);
     setRestartedSuperstep(checkpoint);
+    checkpointStatus = CheckpointStatus.NONE;
     setJobState(ApplicationState.START_SUPERSTEP,
         getApplicationAttempt(),
         checkpoint);

--- a/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
@@ -1741,7 +1741,7 @@ public class BspServiceMaster<I extends WritableComparable,
     if (checkpointFrequency == 0) {
       return CheckpointStatus.NONE;
     }
-    long firstCheckpoint = INPUT_SUPERSTEP + 1 + checkpointFrequency;
+    long firstCheckpoint = INPUT_SUPERSTEP + 1;
     if (getRestartedSuperstep() != UNSET_SUPERSTEP) {
       firstCheckpoint = getRestartedSuperstep() + checkpointFrequency;
     }

--- a/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
@@ -216,7 +216,7 @@ public class BspServiceWorker<I extends WritableComparable,
         graphTaskManager.createUncaughtExceptionHandler());
     workerInfo.setInetSocketAddress(workerServer.getMyAddress(),
         workerServer.getLocalHostOrIp());
-    workerInfo.setTaskId(getTaskPartition());
+    workerInfo.setTaskId((int)getApplicationAttempt() * conf.getMaxWorkers() + getTaskPartition());
     workerClient = new NettyWorkerClient<I, V, E>(context, conf, this,
         graphTaskManager.createUncaughtExceptionHandler());
     workerServer.setFlowControl(workerClient.getFlowControl());
@@ -921,7 +921,7 @@ else[HADOOP_NON_SECURE]*/
 
     String finishedWorkerPath =
         getWorkerFinishedPath(getApplicationAttempt(), getSuperstep()) +
-        "/" + getHostnamePartitionId();
+        "/" + workerInfo.getHostnameId();
     try {
       getZkExt().createExt(finishedWorkerPath,
           workerFinishedInfoObj.toString().getBytes(Charset.defaultCharset()),
@@ -1303,7 +1303,7 @@ else[HADOOP_NON_SECURE]*/
     // Notify master that checkpoint is stored
     String workerWroteCheckpoint =
         getWorkerWroteCheckpointPath(getApplicationAttempt(),
-            getSuperstep()) + "/" + getHostnamePartitionId();
+            getSuperstep()) + "/" + workerInfo.getHostnameId();
     try {
       getZkExt().createExt(workerWroteCheckpoint,
           new byte[0],

--- a/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
@@ -216,7 +216,7 @@ public class BspServiceWorker<I extends WritableComparable,
         graphTaskManager.createUncaughtExceptionHandler());
     workerInfo.setInetSocketAddress(workerServer.getMyAddress(),
         workerServer.getLocalHostOrIp());
-    workerInfo.setTaskId((int)getApplicationAttempt() * conf.getMaxWorkers() + getTaskPartition());
+    workerInfo.setTaskId(getTaskId());
     workerClient = new NettyWorkerClient<I, V, E>(context, conf, this,
         graphTaskManager.createUncaughtExceptionHandler());
     workerServer.setFlowControl(workerClient.getFlowControl());
@@ -243,7 +243,7 @@ public class BspServiceWorker<I extends WritableComparable,
     }
     observers = conf.createWorkerObservers(context);
 
-    WorkerProgress.get().setTaskId(getTaskPartition());
+    WorkerProgress.get().setTaskId(getTaskId());
     workerProgressWriter = conf.trackJobProgressOnClient() ?
         new WorkerProgressWriter(graphTaskManager.getJobProgressTracker()) :
         null;
@@ -1202,7 +1202,7 @@ else[HADOOP_NON_SECURE]*/
     // for workers and masters, the master will clean up the ZooKeeper
     // znodes associated with this job.
     String workerCleanedUpPath = cleanedUpPath  + "/" +
-        getTaskPartition() + WORKER_SUFFIX;
+        getTaskId() + WORKER_SUFFIX;
     try {
       String finalFinishedPath =
           getZkExt().createExt(workerCleanedUpPath,


### PR DESCRIPTION
A couple of fixes that get resuming from checkpoint working.

* Set checkpointStatus to NONE in master when restarting from checkpoint.

Workers already do this, so the job hangs when restarting from checkpoint
while the master waits for workers to create checkpoints they're never
going to create.

* Set unique task id for each worker attempt

Previously, a worker would reuse the task id from the prior attempt. This
gets propagated to the Netty client id, which makes the master think it has
already processed any requests that come from that client, causing it to
discard them. This obviously causes problems.

And also a fix for GIRAPH-1136. We will now checkpoint on superstep 0 if checkpointing is enabled. Let me know if you'd rather I sent a separate PR for this.

Testing:
Ran custom Label Propagation implementation with checkpointing on a ~5b node graph. Manually killed workers (by logging in to worker node and running `kill -9 <pid>`. Ensured that Giraph successfully resumed from most recent checkpoint.