### PR TITLE
GIRAPH-1140: Cleanup temp files in hdfs after job is done

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/graph/GraphTaskManager.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/GraphTaskManager.java
@@ -260,6 +260,9 @@ end[PURE_YARN]*/
     context
         .setStatus("setup: Connected to Zookeeper service " + serverPortList);
     this.graphFunctions = determineGraphFunctions(conf, zkManager);
+    if (this.graphFunctions.isMaster()) {
+      zkManager.cleanupOnExit();
+    }
     try {
       instantiateBspService();
     } catch (IOException e) {

--- a/giraph-core/src/main/java/org/apache/giraph/zk/ZooKeeperManager.java
+++ b/giraph-core/src/main/java/org/apache/giraph/zk/ZooKeeperManager.java
@@ -725,6 +725,18 @@ public class ZooKeeperManager {
   }
 
   /**
+   * Mark files zookeeper creates in hdfs to be deleted on exit.
+   * To be called on master, since it's the last one who finishes.
+   */
+  public void cleanupOnExit() {
+    try {
+      fs.deleteOnExit(baseDirectory);
+    } catch (IOException e) {
+      LOG.error("cleanupOnExit: Failed to delete on exit " + baseDirectory);
+    }
+  }
+
+  /**
    * Do necessary cleanup in zookeeper wrapper.
    */
   public void cleanup() {


### PR DESCRIPTION
Summary: Currently we are not cleaning up temp files we create in hdfs, fix it.

Test Plan: Ran a few jobs (successful, failed, killed), verified files are removed in all cases.