### PR TITLE
GIRAPH-1146: Keep track of number of supersteps when possible

### DIFF
--- a/giraph-block-app-8/src/test/java/org/apache/giraph/writable/kryo/KryoWritableWrapperJava8Test.java
+++ b/giraph-block-app-8/src/test/java/org/apache/giraph/writable/kryo/KryoWritableWrapperJava8Test.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.Random;
 
 import org.apache.giraph.block_app.framework.block.Block;
+import org.apache.giraph.block_app.framework.block.PieceCount;
 import org.apache.giraph.block_app.framework.piece.AbstractPiece;
 import org.apache.giraph.block_app.library.striping.StripingUtils;
 import org.apache.giraph.function.Consumer;
@@ -145,6 +146,11 @@ public class KryoWritableWrapperJava8Test {
 
             @Override
             public void forAllPossiblePieces(Consumer<AbstractPiece> consumer) { }
+
+            @Override
+            public PieceCount getPieceCount() {
+              return PieceCount.createUnknownCount();
+            }
           })));
   }
 

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/BlockUtils.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/BlockUtils.java
@@ -26,6 +26,7 @@ import org.apache.giraph.block_app.framework.api.giraph.BlockComputation;
 import org.apache.giraph.block_app.framework.api.giraph.BlockMasterCompute;
 import org.apache.giraph.block_app.framework.api.giraph.BlockWorkerContext;
 import org.apache.giraph.block_app.framework.block.Block;
+import org.apache.giraph.block_app.framework.block.PieceCount;
 import org.apache.giraph.block_app.framework.piece.AbstractPiece;
 import org.apache.giraph.block_app.framework.piece.Piece;
 import org.apache.giraph.conf.BooleanConfOption;
@@ -146,6 +147,11 @@ public class BlockUtils {
     Block executionBlock = blockFactory.createBlock(immConf);
     checkBlockTypes(
         executionBlock, blockFactory.createExecutionStage(immConf), immConf);
+
+    PieceCount pieceCount = executionBlock.getPieceCount();
+    if (pieceCount.isKnown()) {
+      GiraphConstants.SUPERSTEP_COUNT.set(conf, pieceCount.getCount() + 1);
+    }
 
     // check for non 'static final' fields in BlockFactories
     Class<?> bfClass = blockFactory.getClass();

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/Block.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/Block.java
@@ -56,4 +56,12 @@ public interface Block extends Iterable<AbstractPiece> {
    * without actually executing them.
    */
   void forAllPossiblePieces(Consumer<AbstractPiece> consumer);
+
+  /**
+   * How many pieces are in this block.
+   * Sometimes we don't know (eg RepeatBlock).
+   *
+   * @return How many pieces are in this block.
+   */
+  PieceCount getPieceCount();
 }

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/EmptyBlock.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/EmptyBlock.java
@@ -36,4 +36,9 @@ public final class EmptyBlock implements Block {
   @Override
   public void forAllPossiblePieces(Consumer<AbstractPiece> consumer) {
   }
+
+  @Override
+  public PieceCount getPieceCount() {
+    return new PieceCount(0);
+  }
 }

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/FilteringBlock.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/FilteringBlock.java
@@ -110,4 +110,9 @@ public final class FilteringBlock<I extends WritableComparable,
   public void forAllPossiblePieces(Consumer<AbstractPiece> consumer) {
     block.forAllPossiblePieces(consumer);
   }
+
+  @Override
+  public PieceCount getPieceCount() {
+    return block.getPieceCount();
+  }
 }

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/IfBlock.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/IfBlock.java
@@ -61,6 +61,14 @@ public final class IfBlock implements Block {
   }
 
   @Override
+  public PieceCount getPieceCount() {
+    PieceCount thenCount = thenBlock.getPieceCount();
+    PieceCount elseCount = elseBlock.getPieceCount();
+    return thenCount.equals(elseCount) ?
+        thenCount : PieceCount.createUnknownCount();
+  }
+
+  @Override
   public String toString() {
     if (elseBlock instanceof EmptyBlock) {
       return "IfBlock(" + thenBlock + ")";

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/PieceCount.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/PieceCount.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.giraph.block_app.framework.block;
+
+import com.google.common.base.Objects;
+
+/**
+ * Number of pieces
+ */
+public class PieceCount {
+  private boolean known;
+  private int count;
+
+  public PieceCount(int count) {
+    known = true;
+    this.count = count;
+  }
+
+  private PieceCount() {
+    known = false;
+  }
+
+  public static PieceCount createUnknownCount() {
+    return new PieceCount();
+  }
+
+
+  public PieceCount add(PieceCount other) {
+    if (!this.known || !other.known) {
+      known = false;
+    } else {
+      count += other.count;
+    }
+    return this;
+  }
+
+  public PieceCount multiply(int value) {
+    count *= value;
+    return this;
+  }
+
+  public int getCount() {
+    if (known) {
+      return count;
+    } else {
+      throw new IllegalStateException(
+          "Can't get superstep count when it's unknown");
+    }
+  }
+
+  public boolean isKnown() {
+    return known;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof PieceCount) {
+      PieceCount other = (PieceCount) obj;
+      if (known) {
+        return other.known && other.count == count;
+      } else {
+        return !other.known;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(known, count);
+  }
+}

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/RepeatBlock.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/RepeatBlock.java
@@ -32,10 +32,12 @@ import com.google.common.collect.Iterables;
 @SuppressWarnings("rawtypes")
 public final class RepeatBlock implements Block {
   private final Block block;
+  private final boolean constantRepeatTimes;
   private final IntSupplier repeatTimes;
 
   public RepeatBlock(final int repeatTimes, Block block) {
     this.block = block;
+    this.constantRepeatTimes = true;
     this.repeatTimes = new IntSupplier() {
       @Override
       public int get() {
@@ -56,6 +58,7 @@ public final class RepeatBlock implements Block {
    */
   public RepeatBlock(IntSupplier repeatTimes, Block block) {
     this.block = block;
+    this.constantRepeatTimes = false;
     this.repeatTimes = repeatTimes;
   }
 
@@ -78,6 +81,13 @@ public final class RepeatBlock implements Block {
   @Override
   public void forAllPossiblePieces(Consumer<AbstractPiece> consumer) {
     block.forAllPossiblePieces(consumer);
+  }
+
+  @Override
+  public PieceCount getPieceCount() {
+    return constantRepeatTimes ?
+        block.getPieceCount().multiply(repeatTimes.get()) :
+        PieceCount.createUnknownCount();
   }
 
   @Override

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/RepeatUntilBlock.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/RepeatUntilBlock.java
@@ -75,6 +75,11 @@ public final class RepeatUntilBlock implements Block {
   }
 
   @Override
+  public PieceCount getPieceCount() {
+    return PieceCount.createUnknownCount();
+  }
+
+  @Override
   public String toString() {
     return "RepeatUntilBlock(" + repeatTimes + " * " + block + ")";
   }

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/SequenceBlock.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/block/SequenceBlock.java
@@ -54,6 +54,15 @@ public final class SequenceBlock implements Block {
   }
 
   @Override
+  public PieceCount getPieceCount() {
+    PieceCount ret = new PieceCount(0);
+    for (Block block : blocks) {
+      ret.add(block.getPieceCount());
+    }
+    return ret;
+  }
+
+  @Override
   public String toString() {
     return "SequenceBlock" + Arrays.toString(blocks);
   }

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/piece/AbstractPiece.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/piece/AbstractPiece.java
@@ -26,6 +26,7 @@ import org.apache.giraph.block_app.framework.api.BlockWorkerContextSendApi;
 import org.apache.giraph.block_app.framework.api.BlockWorkerReceiveApi;
 import org.apache.giraph.block_app.framework.api.BlockWorkerSendApi;
 import org.apache.giraph.block_app.framework.block.Block;
+import org.apache.giraph.block_app.framework.block.PieceCount;
 import org.apache.giraph.block_app.framework.piece.interfaces.VertexPostprocessor;
 import org.apache.giraph.block_app.framework.piece.interfaces.VertexReceiver;
 import org.apache.giraph.block_app.framework.piece.interfaces.VertexSender;
@@ -260,6 +261,11 @@ public abstract class AbstractPiece<I extends WritableComparable,
   @Override
   public void forAllPossiblePieces(Consumer<AbstractPiece> consumer) {
     consumer.apply(this);
+  }
+
+  @Override
+  public PieceCount getPieceCount() {
+    return new PieceCount(1);
   }
 
   @Override

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/piece/delegate/DelegatePiece.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/piece/delegate/DelegatePiece.java
@@ -26,6 +26,7 @@ import org.apache.giraph.block_app.framework.api.BlockWorkerContextReceiveApi;
 import org.apache.giraph.block_app.framework.api.BlockWorkerContextSendApi;
 import org.apache.giraph.block_app.framework.api.BlockWorkerReceiveApi;
 import org.apache.giraph.block_app.framework.api.BlockWorkerSendApi;
+import org.apache.giraph.block_app.framework.block.PieceCount;
 import org.apache.giraph.block_app.framework.piece.AbstractPiece;
 import org.apache.giraph.block_app.framework.piece.interfaces.VertexPostprocessor;
 import org.apache.giraph.block_app.framework.piece.interfaces.VertexReceiver;
@@ -247,6 +248,11 @@ public class DelegatePiece<I extends WritableComparable, V extends Writable,
     for (AbstractPiece<I, V, E, M, WV, WM, S> innerPiece : innerPieces) {
       innerPiece.forAllPossiblePieces(consumer);
     }
+  }
+
+  @Override
+  public PieceCount getPieceCount() {
+    return new PieceCount(1);
   }
 
   @SuppressWarnings("deprecation")

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/migration/MigrationFullBlockFactory.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/migration/MigrationFullBlockFactory.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 
 import org.apache.giraph.block_app.framework.AbstractBlockFactory;
 import org.apache.giraph.block_app.framework.block.Block;
+import org.apache.giraph.block_app.framework.block.PieceCount;
 import org.apache.giraph.block_app.framework.block.SequenceBlock;
 import org.apache.giraph.block_app.framework.piece.AbstractPiece;
 import org.apache.giraph.block_app.framework.piece.Piece;
@@ -100,6 +101,11 @@ public abstract class MigrationFullBlockFactory
           @Override
           public void forAllPossiblePieces(Consumer<AbstractPiece> consumer) {
             consumer.apply(curPiece);
+          }
+
+          @Override
+          public PieceCount getPieceCount() {
+            return curPiece.getPieceCount();
           }
         }
     );

--- a/giraph-block-app/src/test/java/org/apache/giraph/block_app/framework/BlockApiHandleTest.java
+++ b/giraph-block-app/src/test/java/org/apache/giraph/block_app/framework/BlockApiHandleTest.java
@@ -26,6 +26,7 @@ import org.apache.giraph.block_app.framework.api.BlockWorkerSendApi;
 import org.apache.giraph.block_app.framework.api.local.LocalBlockRunner;
 import org.apache.giraph.block_app.framework.block.Block;
 import org.apache.giraph.block_app.framework.block.BlockWithApiHandle;
+import org.apache.giraph.block_app.framework.block.PieceCount;
 import org.apache.giraph.block_app.framework.piece.AbstractPiece;
 import org.apache.giraph.block_app.framework.piece.DefaultParentPiece;
 import org.apache.giraph.block_app.framework.piece.interfaces.VertexReceiver;
@@ -196,6 +197,11 @@ public class BlockApiHandleTest {
       @Override
       public void forAllPossiblePieces(Consumer<AbstractPiece> consumer) {
         piece.forAllPossiblePieces(consumer);
+      }
+
+      @Override
+      public PieceCount getPieceCount() {
+        return piece.getPieceCount();
       }
 
       @Override

--- a/giraph-block-app/src/test/java/org/apache/giraph/block_app/framework/block/TestIfBlock.java
+++ b/giraph-block-app/src/test/java/org/apache/giraph/block_app/framework/block/TestIfBlock.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import org.apache.giraph.block_app.framework.piece.Piece;
 import org.apache.giraph.function.Supplier;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestIfBlock {
@@ -53,6 +54,7 @@ public class TestIfBlock {
     BlockTestingUtils.testIndependence(
         Arrays.asList(piece1, piece2),
         ifBlock);
+    Assert.assertFalse(ifBlock.getPieceCount().isKnown());
   }
 
   @Test
@@ -69,6 +71,7 @@ public class TestIfBlock {
     BlockTestingUtils.testIndependence(
         Arrays.asList(piece1, piece2),
         ifBlock);
+    Assert.assertFalse(ifBlock.getPieceCount().isKnown());
   }
 
   @Test
@@ -83,6 +86,19 @@ public class TestIfBlock {
     BlockTestingUtils.testNestedRepeatBlock(
             Arrays.asList(piece1, piece2),
             ifBlock);
+    Assert.assertFalse(ifBlock.getPieceCount().isKnown());
   }
 
+  @Test
+  public void testIfThenElsePieceCount() {
+    Piece piece1 = new Piece();
+    Piece piece2 = new Piece();
+    Block ifBlock = new IfBlock(
+        TRUE_SUPPLIER,
+        piece1,
+        piece2
+    );
+    Assert.assertTrue(ifBlock.getPieceCount().isKnown());
+    Assert.assertEquals(1, ifBlock.getPieceCount().getCount());
+  }
 }

--- a/giraph-block-app/src/test/java/org/apache/giraph/block_app/framework/block/TestRepeatBlock.java
+++ b/giraph-block-app/src/test/java/org/apache/giraph/block_app/framework/block/TestRepeatBlock.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.giraph.block_app.framework.piece.AbstractPiece;
 import org.apache.giraph.block_app.framework.piece.Piece;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.Iterables;
@@ -46,6 +47,7 @@ public class TestRepeatBlock {
     BlockTestingUtils.testIndependence(
             Iterables.concat(Collections.nCopies(REPEAT_TIMES, Arrays.asList(piece1, piece2))),
             repeatBlock);
+    Assert.assertEquals(REPEAT_TIMES * 2, repeatBlock.getPieceCount().getCount());
   }
 
   @Test

--- a/giraph-block-app/src/test/java/org/apache/giraph/block_app/framework/block/TestRepeatUntilBlock.java
+++ b/giraph-block-app/src/test/java/org/apache/giraph/block_app/framework/block/TestRepeatUntilBlock.java
@@ -27,6 +27,7 @@ import org.apache.giraph.block_app.framework.piece.AbstractPiece;
 import org.apache.giraph.block_app.framework.piece.Piece;
 import org.apache.giraph.function.Supplier;
 import org.apache.giraph.function.primitive.PrimitiveRefs.IntRef;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.Iterables;
@@ -58,6 +59,8 @@ public class TestRepeatUntilBlock {
     BlockTestingUtils.testIndependence(
       Iterables.concat(Collections.nCopies(REPEAT_TIMES, Arrays.asList(piece1, piece2))),
       repeatBlock);
+    Assert.assertEquals(2, innerBlock.getPieceCount().getCount());
+    Assert.assertFalse(repeatBlock.getPieceCount().isKnown());
   }
 
   @Test

--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -1261,5 +1261,9 @@ public interface GiraphConstants {
       new LongConfOption("giraph.waitForOtherWorkersMsec",
           HOURS.toMillis(48),
           "How long should workers wait to finish superstep");
+
+  /** Number of supersteps job will run for */
+  IntConfOption SUPERSTEP_COUNT = new IntConfOption("giraph.numSupersteps", -1,
+      "Number of supersteps job will run for");
 }
 // CHECKSTYLE: resume InterfaceIsTypeCheck

--- a/giraph-core/src/main/java/org/apache/giraph/job/CombinedWorkerProgress.java
+++ b/giraph-core/src/main/java/org/apache/giraph/job/CombinedWorkerProgress.java
@@ -20,6 +20,7 @@ package org.apache.giraph.job;
 
 import com.google.common.collect.Iterables;
 import org.apache.giraph.conf.FloatConfOption;
+import org.apache.giraph.conf.GiraphConstants;
 import org.apache.giraph.master.MasterProgress;
 import org.apache.giraph.worker.WorkerProgress;
 import org.apache.giraph.worker.WorkerProgressStats;
@@ -50,6 +51,8 @@ public class CombinedWorkerProgress extends WorkerProgressStats {
    * warning will be printed
    */
   private double normalFreeMemoryFraction;
+  /** Total number of supersteps */
+  private final int superstepCount;
   /**
    * How many workers have reported that they are in highest reported
    * superstep
@@ -86,6 +89,7 @@ public class CombinedWorkerProgress extends WorkerProgressStats {
       MasterProgress masterProgress, Configuration conf) {
     this.masterProgress = masterProgress;
     normalFreeMemoryFraction = NORMAL_FREE_MEMORY_FRACTION.get(conf);
+    superstepCount = GiraphConstants.SUPERSTEP_COUNT.get(conf);
     for (WorkerProgress workerProgress : workerProgresses) {
       if (workerProgress.getCurrentSuperstep() > currentSuperstep) {
         verticesToCompute = 0;
@@ -180,8 +184,12 @@ public class CombinedWorkerProgress extends WorkerProgressStats {
         }
       }
     } else if (isComputeSuperstep()) {
-      sb.append("Compute superstep ").append(currentSuperstep).append(": ");
-      sb.append(verticesComputed).append(" out of ").append(
+      sb.append("Compute superstep ").append(currentSuperstep);
+      if (superstepCount > 0) {
+        // Supersteps are 0..superstepCount-1 so subtract 1 here
+        sb.append(" (out of ").append(superstepCount - 1).append(")");
+      }
+      sb.append(": ").append(verticesComputed).append(" out of ").append(
           verticesToCompute).append(" vertices computed; ");
       sb.append(partitionsComputed).append(" out of ").append(
           partitionsToCompute).append(" partitions computed");


### PR DESCRIPTION
Summary: In many cases we know how many supersteps are there going to be. We can keep track of it and log it with progress.

Test Plan: Ran a job, example log line:
 Data from 3 workers - Compute superstep 5 (out of 6): 171824 out of 1304814 vertices computed; 19 out of 252 partitions computed