### PR TITLE
[GIRAPH-1147] Store timestamps when various fractions of input were done

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/comm/requests/AskForInputSplitRequest.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/requests/AskForInputSplitRequest.java
@@ -34,16 +34,25 @@ public class AskForInputSplitRequest extends WritableRequest
   private InputType splitType;
   /** Task id of worker which requested the split */
   private int workerTaskId;
+  /**
+   * Whether this is the first split a thread is requesting,
+   * or this request indicates that previously requested input split was done
+   */
+  private boolean isFirstSplit;
 
   /**
    * Constructor
    *
    * @param splitType Type of split we are requesting
    * @param workerTaskId Task id of worker which requested the split
+   * @param isFirstSplit Whether this is the first split a thread is requesting,
+   *   or this request indicates that previously requested input split was done
    */
-  public AskForInputSplitRequest(InputType splitType, int workerTaskId) {
+  public AskForInputSplitRequest(InputType splitType, int workerTaskId,
+      boolean isFirstSplit) {
     this.splitType = splitType;
     this.workerTaskId = workerTaskId;
+    this.isFirstSplit = isFirstSplit;
   }
 
   /**
@@ -54,19 +63,22 @@ public class AskForInputSplitRequest extends WritableRequest
 
   @Override
   public void doRequest(MasterGlobalCommHandler commHandler) {
-    commHandler.getInputSplitsHandler().sendSplitTo(splitType, workerTaskId);
+    commHandler.getInputSplitsHandler().sendSplitTo(
+        splitType, workerTaskId, isFirstSplit);
   }
 
   @Override
   void readFieldsRequest(DataInput in) throws IOException {
     splitType = InputType.values()[in.readInt()];
     workerTaskId = in.readInt();
+    isFirstSplit = in.readBoolean();
   }
 
   @Override
   void writeRequest(DataOutput out) throws IOException {
     out.writeInt(splitType.ordinal());
     out.writeInt(workerTaskId);
+    out.writeBoolean(isFirstSplit);
   }
 
   @Override

--- a/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
@@ -846,7 +846,7 @@ public class BspServiceMaster<I extends WritableComparable,
           globalCommHandler = new MasterGlobalCommHandler(
               new MasterAggregatorHandler(getConfiguration(), getContext()),
               new MasterInputSplitsHandler(
-                  getConfiguration().useInputSplitLocality()));
+                  getConfiguration().useInputSplitLocality(), getContext()));
           aggregatorTranslation = new AggregatorToGlobalCommTranslation(
               getConfiguration(), globalCommHandler);
 

--- a/giraph-core/src/main/java/org/apache/giraph/worker/InputSplitsCallable.java
+++ b/giraph-core/src/main/java/org/apache/giraph/worker/InputSplitsCallable.java
@@ -208,15 +208,19 @@ public abstract class InputSplitsCallable<I extends WritableComparable,
   @Override
   public VertexEdgeCount call() {
     VertexEdgeCount vertexEdgeCount = new VertexEdgeCount();
-    byte[] serializedInputSplit;
     int inputSplitsProcessed = 0;
     try {
       OutOfCoreEngine oocEngine = serviceWorker.getServerData().getOocEngine();
       if (oocEngine != null) {
         oocEngine.processingThreadStart();
       }
-      while ((serializedInputSplit =
-          splitsHandler.reserveInputSplit(getInputType())) != null) {
+      while (true) {
+        byte[] serializedInputSplit = splitsHandler.reserveInputSplit(
+            getInputType(), inputSplitsProcessed == 0);
+        if (serializedInputSplit == null) {
+          // No splits left
+          break;
+        }
         // If out-of-core mechanism is used, check whether this thread
         // can stay active or it should temporarily suspend and stop
         // processing and generating more data for the moment.

--- a/giraph-core/src/main/java/org/apache/giraph/worker/WorkerInputSplitsHandler.java
+++ b/giraph-core/src/main/java/org/apache/giraph/worker/WorkerInputSplitsHandler.java
@@ -91,12 +91,14 @@ public class WorkerInputSplitsHandler {
    * have been created.
    *
    * @param splitType Type of split
+   * @param isFirstSplit Whether this is the first split input thread reads
    * @return reserved InputSplit or null if no unfinished InputSplits exist
    */
-  public byte[] reserveInputSplit(InputType splitType) {
+  public byte[] reserveInputSplit(InputType splitType, boolean isFirstSplit) {
     // Send request
     workerClient.sendWritableRequest(masterTaskId,
-        new AskForInputSplitRequest(splitType, workerInfo.getTaskId()));
+        new AskForInputSplitRequest(
+            splitType, workerInfo.getTaskId(), isFirstSplit));
     try {
       // Wait for some split to become available
       byte[] serializedInputSplit = availableInputSplits.get(splitType).take();


### PR DESCRIPTION
Summary: In order to evaluate how read stragglers affect job performance, add a way to expose timestamps when various fractions of input were done reading through counters.

Test Plan: Ran a big job and verified counters are set correctly.