### PR TITLE
Fix initialization of IdAndValueArrayEdges and IdAndNullArrayEdges

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/edge/IdAndNullArrayEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IdAndNullArrayEdges.java
@@ -49,8 +49,6 @@ public class IdAndNullArrayEdges<I extends WritableComparable>
 
   /** Array of target vertex ids. */
   private WArrayList<I> neighbors;
-  /** Type operations for ID */
-  private PrimitiveIdTypeOps<I> idTypeOps;
 
   @Override
   public
@@ -61,7 +59,8 @@ public class IdAndNullArrayEdges<I extends WritableComparable>
   @Override
   public void setConf(
       ImmutableClassesGiraphConfiguration<I, Writable, NullWritable> conf) {
-    idTypeOps = TypeOpsUtils.getPrimitiveIdTypeOps(conf.getVertexIdClass());
+    PrimitiveIdTypeOps<I> idTypeOps =
+        TypeOpsUtils.getPrimitiveIdTypeOps(conf.getVertexIdClass());
     neighbors = idTypeOps.createArrayList(10);
     if (!conf.getEdgeValueClass().equals(NullWritable.class)) {
       throw new IllegalArgumentException(
@@ -77,7 +76,8 @@ public class IdAndNullArrayEdges<I extends WritableComparable>
 
   @Override
   public void initialize(int capacity) {
-    neighbors = idTypeOps.createArrayList(capacity);
+    neighbors.clear();
+    neighbors.setCapacity(capacity);
   }
 
   @Override

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IdAndValueArrayEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IdAndValueArrayEdges.java
@@ -53,6 +53,10 @@ public class IdAndValueArrayEdges<I extends WritableComparable,
   private WArrayList<I> neighborIds;
   /** Array of edge values. */
   private WArrayList<E> neighborEdgeValues;
+  /** Type operations for vertex ID */
+  private PrimitiveIdTypeOps<I> idTypeOps;
+  /** Type operations for edge value */
+  private PrimitiveTypeOps<E> edgeTypeOps;
 
   @Override
   public ImmutableClassesGiraphConfiguration<I, Writable, E> getConf() {
@@ -62,12 +66,10 @@ public class IdAndValueArrayEdges<I extends WritableComparable,
   @Override
   public void setConf(
       ImmutableClassesGiraphConfiguration<I, Writable, E> conf) {
-    PrimitiveIdTypeOps<I> idTypeOps =
-        TypeOpsUtils.getPrimitiveIdTypeOps(conf.getVertexIdClass());
+    idTypeOps = TypeOpsUtils.getPrimitiveIdTypeOps(conf.getVertexIdClass());
     neighborIds = idTypeOps.createArrayList(10);
 
-    PrimitiveTypeOps<E> edgeTypeOps =
-        TypeOpsUtils.getPrimitiveTypeOps(conf.getEdgeValueClass());
+    edgeTypeOps = TypeOpsUtils.getPrimitiveTypeOps(conf.getEdgeValueClass());
     neighborEdgeValues = edgeTypeOps.createArrayList(10);
   }
 
@@ -78,8 +80,8 @@ public class IdAndValueArrayEdges<I extends WritableComparable,
 
   @Override
   public void initialize(int capacity) {
-    neighborIds.setCapacity(capacity);
-    neighborEdgeValues.setCapacity(capacity);
+    neighborIds = idTypeOps.createArrayList(capacity);
+    neighborEdgeValues = edgeTypeOps.createArrayList(capacity);
   }
 
   @Override

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IdAndValueArrayEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IdAndValueArrayEdges.java
@@ -54,10 +54,6 @@ public class IdAndValueArrayEdges<I extends WritableComparable,
   private WArrayList<I> neighborIds;
   /** Array of edge values. */
   private WArrayList<E> neighborEdgeValues;
-  /** Type operations for vertex ID */
-  private PrimitiveIdTypeOps<I> idTypeOps;
-  /** Type operations for edge value */
-  private PrimitiveTypeOps<E> edgeTypeOps;
 
   @Override
   public ImmutableClassesGiraphConfiguration<I, Writable, E> getConf() {
@@ -67,10 +63,12 @@ public class IdAndValueArrayEdges<I extends WritableComparable,
   @Override
   public void setConf(
       ImmutableClassesGiraphConfiguration<I, Writable, E> conf) {
-    idTypeOps = TypeOpsUtils.getPrimitiveIdTypeOps(conf.getVertexIdClass());
+    PrimitiveIdTypeOps<I> idTypeOps =
+        TypeOpsUtils.getPrimitiveIdTypeOps(conf.getVertexIdClass());
     neighborIds = idTypeOps.createArrayList(10);
 
-    edgeTypeOps = TypeOpsUtils.getPrimitiveTypeOps(conf.getEdgeValueClass());
+    PrimitiveTypeOps<E> edgeTypeOps =
+        TypeOpsUtils.getPrimitiveTypeOps(conf.getEdgeValueClass());
     neighborEdgeValues = edgeTypeOps.createArrayList(10);
   }
 
@@ -81,8 +79,10 @@ public class IdAndValueArrayEdges<I extends WritableComparable,
 
   @Override
   public void initialize(int capacity) {
-    neighborIds = idTypeOps.createArrayList(capacity);
-    neighborEdgeValues = edgeTypeOps.createArrayList(capacity);
+    neighborIds.clear();
+    neighborIds.setCapacity(capacity);
+    neighborEdgeValues.clear();
+    neighborEdgeValues.setCapacity(capacity);
   }
 
   @Override

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IdAndValueArrayEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IdAndValueArrayEdges.java
@@ -21,6 +21,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.apache.giraph.conf.ImmutableClassesGiraphConfigurable;
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
@@ -164,6 +165,9 @@ public class IdAndValueArrayEdges<I extends WritableComparable,
 
       @Override
       public Edge<I, E> next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
         neighborIds.getIntoW(index, representativeEdge.getTargetVertexId());
         neighborEdgeValues.getIntoW(index, representativeEdge.getValue());
         index++;
@@ -222,6 +226,9 @@ public class IdAndValueArrayEdges<I extends WritableComparable,
 
       @Override
       public MutableEdge<I, E> next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
         representativeEdge.setIndex(index++);
         return representativeEdge;
       }

--- a/giraph-core/src/test/java/org/apache/giraph/edge/IdAndNullArrayEdgesTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/edge/IdAndNullArrayEdgesTest.java
@@ -21,8 +21,8 @@ import com.google.common.collect.Lists;
 import org.apache.giraph.conf.GiraphConfiguration;
 import org.apache.giraph.conf.GiraphConstants;
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
-import org.apache.hadoop.io.DoubleWritable;
 import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Writable;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,45 +42,44 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 
-public class IdAndValueArrayEdgesTest {
-  private static Edge<LongWritable, DoubleWritable> createEdge(long id) {
-    return EdgeFactory.create(new LongWritable(id), new DoubleWritable((double) id));
+public class IdAndNullArrayEdgesTest {
+  private static Edge<LongWritable, NullWritable> createEdge(long id) {
+    return EdgeFactory.create(new LongWritable(id));
   }
 
-  private static void assertEdges(IdAndValueArrayEdges edges, long... expected) {
+  private static void assertEdges(IdAndNullArrayEdges edges, long... expected) {
     int index = 0;
-    for (Edge<LongWritable, DoubleWritable> edge :
-      (Iterable<Edge<LongWritable, DoubleWritable>>) edges) {
+    for (Edge<LongWritable, NullWritable> edge :
+      (Iterable<Edge<LongWritable, NullWritable>>) edges) {
       Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
-      Assert.assertEquals((double) expected[index], edge.getValue().get(), 0.00001);
       index++;
     }
     Assert.assertEquals(expected.length, index);
   }
 
-  private IdAndValueArrayEdges getEdges() {
+  private IdAndNullArrayEdges getEdges() {
     GiraphConfiguration gc = new GiraphConfiguration();
     GiraphConstants.VERTEX_ID_CLASS.set(gc, LongWritable.class);
-    GiraphConstants.EDGE_VALUE_CLASS.set(gc, DoubleWritable.class);
-    ImmutableClassesGiraphConfiguration<LongWritable, Writable, DoubleWritable> conf =
-        new ImmutableClassesGiraphConfiguration<LongWritable, Writable, DoubleWritable>(gc);
-    IdAndValueArrayEdges ret = new IdAndValueArrayEdges();
+    GiraphConstants.EDGE_VALUE_CLASS.set(gc, NullWritable.class);
+    ImmutableClassesGiraphConfiguration<LongWritable, Writable, NullWritable> conf =
+        new ImmutableClassesGiraphConfiguration<LongWritable, Writable, NullWritable>(gc);
+    IdAndNullArrayEdges ret = new IdAndNullArrayEdges();
     ret.setConf(
-      new ImmutableClassesGiraphConfiguration<LongWritable, Writable, DoubleWritable>(conf));
+      new ImmutableClassesGiraphConfiguration<LongWritable, Writable, NullWritable>(conf));
     return ret;
   }
 
   @Test
   public void testEdges() {
-    IdAndValueArrayEdges edges = getEdges();
+    IdAndNullArrayEdges edges = getEdges();
 
-    List<Edge<LongWritable, DoubleWritable>> initialEdges = Lists.newArrayList(
+    List<Edge<LongWritable, NullWritable>> initialEdges = Lists.newArrayList(
         createEdge(1), createEdge(2), createEdge(4));
 
     edges.initialize(initialEdges);
     assertEdges(edges, 1, 2, 4);
 
-    edges.add(EdgeFactory.createReusable(new LongWritable(3), new DoubleWritable(3.0)));
+    edges.add(EdgeFactory.createReusable(new LongWritable(3)));
     assertEdges(edges, 1, 2, 4, 3); // order matters, it's an array
 
     edges.remove(new LongWritable(2));
@@ -89,16 +88,16 @@ public class IdAndValueArrayEdgesTest {
 
   @Test
   public void testInitialize() {
-    IdAndValueArrayEdges edges = getEdges();
+    IdAndNullArrayEdges edges = getEdges();
 
-    List<Edge<LongWritable, DoubleWritable>> initialEdges = Lists.newArrayList(
+    List<Edge<LongWritable, NullWritable>> initialEdges = Lists.newArrayList(
       createEdge(1), createEdge(2), createEdge(4));
 
     edges.initialize(initialEdges);
     assertEdges(edges, 1, 2, 4);
 
-    edges.add(EdgeFactory.createReusable(new LongWritable(3), new DoubleWritable(3.0)));
-    assertEdges(edges, 1, 2, 4, 3); // order matters, it's an array
+    edges.add(EdgeFactory.createReusable(new LongWritable(3)));
+    assertEdges(edges, 1, 2, 4, 3);
 
     edges.initialize();
     assertEquals(0, edges.size());
@@ -106,7 +105,7 @@ public class IdAndValueArrayEdgesTest {
 
   @Test
   public void testMutateEdges() {
-    IdAndValueArrayEdges edges = getEdges();
+    IdAndNullArrayEdges edges = getEdges();
 
     edges.initialize();
 
@@ -116,7 +115,7 @@ public class IdAndValueArrayEdgesTest {
     }
 
     // Use the mutable iterator to remove edges with even id
-    Iterator<MutableEdge<LongWritable, DoubleWritable>> edgeIt =
+    Iterator<MutableEdge<LongWritable, NullWritable>> edgeIt =
         edges.mutableIterator();
     while (edgeIt.hasNext()) {
       if (edgeIt.next().getTargetVertexId().get() % 2 == 0) {
@@ -127,15 +126,15 @@ public class IdAndValueArrayEdgesTest {
     // We should now have 5 edges
     assertEquals(5, edges.size());
     // The edge ids should be all odd
-    for (Edge<LongWritable, DoubleWritable> edge :
-      (Iterable<Edge<LongWritable, DoubleWritable>>) edges) {
+    for (Edge<LongWritable, NullWritable> edge :
+      (Iterable<Edge<LongWritable, NullWritable>>) edges) {
       assertEquals(1, edge.getTargetVertexId().get() % 2);
     }
   }
 
   @Test
   public void testSerialization() throws IOException {
-    IdAndValueArrayEdges edges = getEdges();
+    IdAndNullArrayEdges edges = getEdges();
 
     edges.initialize();
 
@@ -145,7 +144,7 @@ public class IdAndValueArrayEdgesTest {
     }
 
     // Use the mutable iterator to remove edges with even id
-    Iterator<MutableEdge<LongWritable, DoubleWritable>> edgeIt =
+    Iterator<MutableEdge<LongWritable, NullWritable>> edgeIt =
         edges.mutableIterator();
     while (edgeIt.hasNext()) {
       if (edgeIt.next().getTargetVertexId().get() % 2 == 0) {
@@ -174,10 +173,9 @@ public class IdAndValueArrayEdgesTest {
     long[] ids = new long[]{9, 1, 7, 3, 5};
     int index = 0;
 
-    for (Edge<LongWritable, DoubleWritable> edge :
-      (Iterable<Edge<LongWritable, DoubleWritable>>) edges) {
+    for (Edge<LongWritable, NullWritable> edge :
+      (Iterable<Edge<LongWritable, NullWritable>>) edges) {
       assertEquals(ids[index], edge.getTargetVertexId().get());
-      assertEquals((double) ids[index], edge.getValue().get(), 0.00001);
       index++;
     }
     assertEquals(ids.length, index);
@@ -185,9 +183,9 @@ public class IdAndValueArrayEdgesTest {
 
   @Test
   public void testParallelEdges() {
-    IdAndValueArrayEdges edges = getEdges();
+    IdAndNullArrayEdges edges = getEdges();
 
-    List<Edge<LongWritable, DoubleWritable>> initialEdges = Lists.newArrayList(
+    List<Edge<LongWritable, NullWritable>> initialEdges = Lists.newArrayList(
         createEdge(2), createEdge(2), createEdge(2));
 
     edges.initialize(initialEdges);
@@ -196,7 +194,7 @@ public class IdAndValueArrayEdgesTest {
     edges.remove(new LongWritable(2));
     assertEquals(0, edges.size());
 
-    edges.add(EdgeFactory.create(new LongWritable(2), new DoubleWritable(2.0)));
+    edges.add(EdgeFactory.create(new LongWritable(2)));
     assertEquals(1, edges.size());
 
     assertEquals(1, edges.size());
@@ -204,21 +202,21 @@ public class IdAndValueArrayEdgesTest {
 
   @Test
   public void testEdgeValues() {
-    IdAndValueArrayEdges edges = getEdges();
+    IdAndNullArrayEdges edges = getEdges();
     Set<Long> testValues = new HashSet<Long>();
     testValues.add(0L);
     testValues.add((long) Integer.MAX_VALUE);
     testValues.add(Long.MAX_VALUE);
 
-    List<Edge<LongWritable, DoubleWritable>> initialEdges =
-      new ArrayList<Edge<LongWritable, DoubleWritable>>();
+    List<Edge<LongWritable, NullWritable>> initialEdges =
+      new ArrayList<Edge<LongWritable, NullWritable>>();
     for(Long id : testValues) {
       initialEdges.add(createEdge(id));
     }
 
     edges.initialize(initialEdges);
 
-    Iterator<MutableEdge<LongWritable, DoubleWritable>> edgeIt =
+    Iterator<MutableEdge<LongWritable, NullWritable>> edgeIt =
         edges.mutableIterator();
     while (edgeIt.hasNext()) {
       long value = edgeIt.next().getTargetVertexId().get();
@@ -228,9 +226,9 @@ public class IdAndValueArrayEdgesTest {
 
   @Test
   public void testAddedSmallerValues() {
-    IdAndValueArrayEdges edges = getEdges();
+    IdAndNullArrayEdges edges = getEdges();
 
-    List<Edge<LongWritable, DoubleWritable>> initialEdges = Lists.newArrayList(
+    List<Edge<LongWritable, NullWritable>> initialEdges = Lists.newArrayList(
         createEdge(100));
 
     edges.initialize(initialEdges);

--- a/giraph-core/src/test/java/org/apache/giraph/edge/IdAndValueArrayEdgesTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/edge/IdAndValueArrayEdgesTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.giraph.edge;
+
+import com.google.common.collect.Lists;
+import org.apache.giraph.conf.GiraphConfiguration;
+import org.apache.giraph.conf.GiraphConstants;
+import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Writable;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class IdAndValueArrayEdgesTest {
+  private static Edge<LongWritable, DoubleWritable> createEdge(long id) {
+    return EdgeFactory.create(new LongWritable(id), new DoubleWritable((double) id));
+  }
+
+  private static void assertEdges(IdAndValueArrayEdges edges, long... expected) {
+    int index = 0;
+    for (Edge<LongWritable, DoubleWritable> edge :
+      (Iterable<Edge<LongWritable, DoubleWritable>>) edges) {
+      Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
+      Assert.assertEquals((double) expected[index], edge.getValue().get(), 0.00001);
+      index++;
+    }
+    Assert.assertEquals(expected.length, index);
+  }
+
+  private IdAndValueArrayEdges getEdges() {
+    GiraphConfiguration gc = new GiraphConfiguration();
+    GiraphConstants.VERTEX_ID_CLASS.set(gc, LongWritable.class);
+    GiraphConstants.EDGE_VALUE_CLASS.set(gc, DoubleWritable.class);
+    ImmutableClassesGiraphConfiguration<LongWritable, Writable, DoubleWritable> conf =
+        new ImmutableClassesGiraphConfiguration<LongWritable, Writable, DoubleWritable>(gc);
+    IdAndValueArrayEdges ret = new IdAndValueArrayEdges();
+    ret.setConf(
+      new ImmutableClassesGiraphConfiguration<LongWritable, Writable, DoubleWritable>(conf));
+    return ret;
+  }
+
+  @Test
+  public void testEdges() {
+    IdAndValueArrayEdges edges = getEdges();
+
+    List<Edge<LongWritable, DoubleWritable>> initialEdges = Lists.newArrayList(
+        createEdge(1), createEdge(2), createEdge(4));
+
+    edges.initialize(initialEdges);
+    assertEdges(edges, 1, 2, 4);
+
+    edges.add(EdgeFactory.createReusable(new LongWritable(3), new DoubleWritable(3.0)));
+    assertEdges(edges, 1, 2, 4, 3); // order matters, it's an array
+
+    edges.remove(new LongWritable(2));
+    assertEdges(edges, 1, 3, 4);
+  }
+
+  @Test
+  public void testInitialize() {
+    IdAndValueArrayEdges edges = getEdges();
+
+    List<Edge<LongWritable, DoubleWritable>> initialEdges = Lists.newArrayList(
+      createEdge(1), createEdge(2), createEdge(4));
+
+    edges.initialize(initialEdges);
+    assertEdges(edges, 1, 2, 4);
+
+    edges.add(EdgeFactory.createReusable(new LongWritable(3), new DoubleWritable(3.0)));
+    assertEdges(edges, 1, 2, 4, 3); // order matters, it's an array
+
+    edges.initialize();
+    assertEquals(0, edges.size());
+  }
+
+  @Test
+  public void testMutateEdges() {
+    IdAndValueArrayEdges edges = getEdges();
+
+    edges.initialize();
+
+    // Add 10 edges with id i, for i = 0..9
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
+
+    // Use the mutable iterator to remove edges with even id
+    Iterator<MutableEdge<LongWritable, DoubleWritable>> edgeIt =
+        edges.mutableIterator();
+    while (edgeIt.hasNext()) {
+      if (edgeIt.next().getTargetVertexId().get() % 2 == 0) {
+        edgeIt.remove();
+      }
+    }
+
+    // We should now have 5 edges
+    assertEquals(5, edges.size());
+    // The edge ids should be all odd
+    for (Edge<LongWritable, DoubleWritable> edge :
+      (Iterable<Edge<LongWritable, DoubleWritable>>) edges) {
+      assertEquals(1, edge.getTargetVertexId().get() % 2);
+    }
+  }
+
+  @Test
+  public void testSerialization() throws IOException {
+    IdAndValueArrayEdges edges = getEdges();
+
+    edges.initialize();
+
+    // Add 10 edges with id i, for i = 0..9
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
+
+    // Use the mutable iterator to remove edges with even id
+    Iterator<MutableEdge<LongWritable, DoubleWritable>> edgeIt =
+        edges.mutableIterator();
+    while (edgeIt.hasNext()) {
+      if (edgeIt.next().getTargetVertexId().get() % 2 == 0) {
+        edgeIt.remove();
+      }
+    }
+
+    // We should now have 5 edges
+    assertEdges(edges, 9, 1, 7, 3, 5); // id order matter because of the implementation
+
+    ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
+    DataOutputStream tempBuffer = new DataOutputStream(arrayStream);
+
+    edges.write(tempBuffer);
+    tempBuffer.close();
+
+    byte[] binary = arrayStream.toByteArray();
+
+    assertTrue("Serialized version should not be empty ", binary.length > 0);
+
+    edges = getEdges();
+    edges.readFields(new DataInputStream(new ByteArrayInputStream(binary)));
+
+    assertEquals(5, edges.size());
+
+    long[] ids = new long[]{9, 1, 7, 3, 5};
+    int index = 0;
+
+    for (Edge<LongWritable, DoubleWritable> edge :
+      (Iterable<Edge<LongWritable, DoubleWritable>>) edges) {
+      assertEquals(ids[index], edge.getTargetVertexId().get());
+      assertEquals((double) ids[index], edge.getValue().get(), 0.00001);
+      index++;
+    }
+    assertEquals(ids.length, index);
+  }
+
+  @Test
+  public void testParallelEdges() {
+    IdAndValueArrayEdges edges = getEdges();
+
+    List<Edge<LongWritable, DoubleWritable>> initialEdges = Lists.newArrayList(
+        createEdge(2), createEdge(2), createEdge(2));
+
+    edges.initialize(initialEdges);
+    assertEquals(3, edges.size());
+
+    edges.remove(new LongWritable(2));
+    assertEquals(0, edges.size());
+
+    edges.add(EdgeFactory.create(new LongWritable(2), new DoubleWritable(2.0)));
+    assertEquals(1, edges.size());
+
+    assertEquals(1, edges.size());
+  }
+
+  @Test
+  public void testEdgeValues() {
+    IdAndValueArrayEdges edges = getEdges();
+    Set<Long> testValues = new HashSet<Long>();
+    testValues.add(0L);
+    testValues.add((long) Integer.MAX_VALUE);
+    testValues.add(Long.MAX_VALUE);
+
+    List<Edge<LongWritable, DoubleWritable>> initialEdges =
+      new ArrayList<Edge<LongWritable, DoubleWritable>>();
+    for(Long id : testValues) {
+      initialEdges.add(createEdge(id));
+    }
+
+    edges.initialize(initialEdges);
+
+    Iterator<MutableEdge<LongWritable, DoubleWritable>> edgeIt =
+        edges.mutableIterator();
+    while (edgeIt.hasNext()) {
+      long value = edgeIt.next().getTargetVertexId().get();
+      assertTrue("Unknown edge found " + value, testValues.remove(value));
+    }
+  }
+
+  @Test
+  public void testAddedSmallerValues() {
+    IdAndValueArrayEdges edges = getEdges();
+
+    List<Edge<LongWritable, DoubleWritable>> initialEdges = Lists.newArrayList(
+        createEdge(100));
+
+    edges.initialize(initialEdges);
+
+    for (int i=0; i<16; i++) {
+      edges.add(createEdge(i));
+    }
+
+    assertEquals(17, edges.size());
+  }
+}


### PR DESCRIPTION
The initialize() method for these implementations does not reset the underlying data structure (array) just like in other implementations (e.g. HashMapEdges). This introduces bugs when the OutEdges implementation is re-used during input.

Test plan:
- new unit tests
- mvn clean install
- internal unit tests
- internal snapshot tests