### PR TITLE
[GIRAPH-1152] Fixing aggregated metric labels

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/metrics/AggregatedMetrics.java
+++ b/giraph-core/src/main/java/org/apache/giraph/metrics/AggregatedMetrics.java
@@ -153,8 +153,8 @@ public class AggregatedMetrics {
     if (aggregatedMetric.hasData()) {
       out.println(header);
       out.println("  mean: " + aggregatedMetric.mean() + " " + unit);
-      printValueFromHost(out, "  smallest: ", unit, aggregatedMetric.max());
-      printValueFromHost(out, "  largest: ", unit, aggregatedMetric.min());
+      printValueFromHost(out, "  smallest: ", unit, aggregatedMetric.min());
+      printValueFromHost(out, "  largest: ", unit, aggregatedMetric.max());
     } else {
       out.println(header + ": NO DATA");
     }


### PR DESCRIPTION
The max value was printed with the label "smallest" and the min with the label "largest", leading to incorrect output like:
compute all partitions
 mean: 54443.80869565217 ms
 smallest: 279802 ms from ip-10-200-102-195.ec2.internal_101
 largest: 11042 ms from ip-10-200-103-132.ec2.internal_422