### PR TITLE
Fix bug in memory estimation

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/ooc/policy/MemoryEstimatorOracle.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/policy/MemoryEstimatorOracle.java
@@ -792,7 +792,6 @@ public class MemoryEstimatorOracle implements OutOfCoreOracle {
         LOG.warn("There are " + coefficient.length +
           " coefficients, but " + validColumnIndices.size() +
           " valid columns in the regression");
-        return false;
       }
 
       double[] beta = mlr.estimateRegressionParameters();

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/policy/MemoryEstimatorOracle.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/policy/MemoryEstimatorOracle.java
@@ -789,8 +789,8 @@ public class MemoryEstimatorOracle implements OutOfCoreOracle {
       List<Integer> validColumnIndices, OLSMultipleLinearRegression mlr) {
 
       if (coefficient.length != validColumnIndices.size()) {
-        LOG.warn("There are " + coefficient.length +
-          " coefficients, but " + validColumnIndices.size() +
+        LOG.info("There are " + coefficient.length +
+          " coefficients, and " + validColumnIndices.size() +
           " valid columns in the regression");
       }
 


### PR DESCRIPTION
Method MemoryEstimatorOracle.calculateRegression() exits if the number of valid columns to use for the regression is not the same as the total number of columns. This is wrong, the regression can still run on only the valid columns. This causes memory estimation to never be used in practice, and OOC starts spilling only when memory usage gets very high.

This is fixed in https://github.com/apache/giraph/pull/34 too, but I want to make these changes one-by-one so that we can test in isolation.

Tests:
- mvn clean install
- Snapshot tests, including snapshot test that uses OOC.
- Run 3 production jobs and verified that this reduces data spills and jobs finish faster. The max % spilled is reduced by more than 40%.

JIRA: https://issues.apache.org/jira/browse/GIRAPH-1160


