### PR TITLE
GIRAPH-1165: Skip iterating through vertices in supersteps with just …

### DIFF
--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/api/giraph/BlockComputation.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/api/giraph/BlockComputation.java
@@ -51,4 +51,9 @@ public final class BlockComputation extends AbstractComputation {
   public void postSuperstep() {
     workerLogic.postSuperstep();
   }
+
+  @Override
+  public boolean isVertexNoOp() {
+    return workerLogic.isVertexNoOp();
+  }
 }

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockWorkerLogic.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockWorkerLogic.java
@@ -19,9 +19,8 @@ package org.apache.giraph.block_app.framework.internal;
 
 import org.apache.giraph.block_app.framework.api.BlockWorkerReceiveApi;
 import org.apache.giraph.block_app.framework.api.BlockWorkerSendApi;
+import org.apache.giraph.block_app.framework.piece.AbstractPiece.InnerVertexReceiver;
 import org.apache.giraph.block_app.framework.piece.AbstractPiece.InnerVertexSender;
-import org.apache.giraph.block_app.framework.piece.interfaces.VertexPostprocessor;
-import org.apache.giraph.block_app.framework.piece.interfaces.VertexReceiver;
 import org.apache.giraph.graph.Vertex;
 
 /**
@@ -31,7 +30,7 @@ import org.apache.giraph.graph.Vertex;
 public class BlockWorkerLogic {
   private final BlockWorkerPieces pieces;
 
-  private transient VertexReceiver receiveFunctions;
+  private transient InnerVertexReceiver receiveFunctions;
   private transient InnerVertexSender sendFunctions;
 
   public BlockWorkerLogic(BlockWorkerPieces pieces) {
@@ -60,11 +59,22 @@ public class BlockWorkerLogic {
   }
 
   public void postSuperstep() {
-    if (receiveFunctions instanceof VertexPostprocessor) {
-      ((VertexPostprocessor) receiveFunctions).postprocess();
+    if (receiveFunctions != null) {
+      receiveFunctions.postprocess();
     }
     if (sendFunctions != null) {
       sendFunctions.postprocess();
     }
+  }
+
+  /**
+   * Return true iff compute() function is empty
+   *
+   * @return True iff compute function is empty, so we know we don't have to
+   * iterate through vertices
+   */
+  public boolean isVertexNoOp() {
+    return (receiveFunctions == null || receiveFunctions.isVertexNoOp()) &&
+        (sendFunctions == null || sendFunctions.isVertexNoOp());
   }
 }

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/PairedPieceAndStage.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/PairedPieceAndStage.java
@@ -25,8 +25,8 @@ import org.apache.giraph.block_app.framework.api.BlockWorkerContextSendApi;
 import org.apache.giraph.block_app.framework.api.BlockWorkerReceiveApi;
 import org.apache.giraph.block_app.framework.api.BlockWorkerSendApi;
 import org.apache.giraph.block_app.framework.piece.AbstractPiece;
+import org.apache.giraph.block_app.framework.piece.AbstractPiece.InnerVertexReceiver;
 import org.apache.giraph.block_app.framework.piece.AbstractPiece.InnerVertexSender;
-import org.apache.giraph.block_app.framework.piece.interfaces.VertexReceiver;
 import org.apache.hadoop.io.Writable;
 
 /**
@@ -73,10 +73,10 @@ public class PairedPieceAndStage<S> {
     }
   }
 
-  public VertexReceiver getVertexReceiver(
+  public InnerVertexReceiver getVertexReceiver(
       BlockWorkerReceiveApi receiveApi) {
     if (piece != null) {
-      return piece.getVertexReceiver(receiveApi, executionStage);
+      return piece.getWrappedVertexReceiver(receiveApi, executionStage);
     }
     return null;
   }

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/piece/delegate/FilteringPiece.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/piece/delegate/FilteringPiece.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import org.apache.giraph.block_app.framework.api.BlockWorkerReceiveApi;
 import org.apache.giraph.block_app.framework.api.BlockWorkerSendApi;
 import org.apache.giraph.block_app.framework.piece.AbstractPiece;
-import org.apache.giraph.block_app.framework.piece.interfaces.VertexReceiver;
 import org.apache.giraph.function.vertex.SupplierFromVertex;
 import org.apache.giraph.graph.Vertex;
 import org.apache.hadoop.io.Writable;
@@ -122,12 +121,17 @@ public class FilteringPiece<I extends WritableComparable, V extends Writable,
           super.vertexSend(vertex);
         }
       }
+
+      @Override
+      public boolean isVertexNoOp() {
+        return toCallSend == null;
+      }
     };
   }
 
   @Override
   protected DelegateWorkerReceiveFunctions delegateWorkerReceiveFunctions(
-      ArrayList<VertexReceiver<I, V, E, M>> workerReceiveFunctions,
+      ArrayList<InnerVertexReceiver> workerReceiveFunctions,
       BlockWorkerReceiveApi<I> workerApi, S executionStage) {
     return new DelegateWorkerReceiveFunctions(workerReceiveFunctions) {
       @Override
@@ -135,6 +139,11 @@ public class FilteringPiece<I extends WritableComparable, V extends Writable,
         if (toCallReceive == null || toCallReceive.get(vertex)) {
           super.vertexReceive(vertex, messages);
         }
+      }
+
+      @Override
+      public boolean isVertexNoOp() {
+        return toCallReceive == null;
       }
     };
   }

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/library/Pieces.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/library/Pieces.java
@@ -59,6 +59,16 @@ public class Pieces {
   private Pieces() { }
 
   /**
+   * Piece which does nothing
+   */
+  public static Piece<WritableComparable, Writable,  Writable, NoMessage,
+      Object> noOpPiece() {
+    return new Piece<WritableComparable, Writable,  Writable, NoMessage,
+        Object>() {
+    };
+  }
+
+  /**
    * For each vertex execute given process function.
    * Computation is happening in send phase of the returned Piece.
    */

--- a/giraph-core/src/main/java/org/apache/giraph/graph/AbstractComputation.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/AbstractComputation.java
@@ -294,4 +294,9 @@ public abstract class AbstractComputation<I extends WritableComparable,
     return allWorkersInfo.getWorkerIndex(
         serviceWorker.getVertexPartitionOwner(vertexId).getWorkerInfo());
   }
+
+  @Override
+  public boolean isVertexNoOp() {
+    return false;
+  }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/graph/Computation.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/Computation.java
@@ -205,4 +205,13 @@ public interface Computation<I extends WritableComparable,
    */
   @SuppressWarnings("unchecked")
   <W extends WorkerContext> W getWorkerContext();
+
+  /**
+   * Check if this Computation doesn't do anything inside of compute() function.
+   * It will be used to skip iterating through vertices, so if it returns true
+   * compute() won't be called at all.
+   *
+   * @return True iff compute function is empty.
+   */
+  boolean isVertexNoOp();
 }

--- a/giraph-core/src/main/java/org/apache/giraph/graph/ComputeCallable.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/ComputeCallable.java
@@ -278,6 +278,15 @@ public class ComputeCallable<I extends WritableComparable, V extends Writable,
       Partition<I, V, E> partition, OutOfCoreEngine oocEngine,
       boolean ignoreExistingVertices)
       throws IOException, InterruptedException {
+    if (computation.isVertexNoOp()) {
+      if (LOG.isInfoEnabled()) {
+        LOG.info("Skipping compute since it's no-op");
+      }
+      return new PartitionStats(partition.getId(), partition.getVertexCount(),
+          0, partition.getEdgeCount(), 0, 0);
+    }
+
+
     PartitionStats partitionStats =
         new PartitionStats(partition.getId(), 0, 0, 0, 0, 0);
     final LongRef verticesComputedProgress = new LongRef(0);


### PR DESCRIPTION
…global logic

Summary: Some supersteps don't do anything with vertices but just do global worker or master computation or perform aggregation. Not iterating through vertices in these cases can save time.

Test Plan: Ran some jobs with supersteps which only do global computation and verified computation is skipped and we save a few seconds per these supersteps