### PR TITLE
GIRAPH-1166: Allow MasterObserver to get superstep aggregated metrics

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
@@ -984,6 +984,9 @@ public class BspServiceMaster<I extends WritableComparable,
       } else {
         printAggregatedMetricsToHDFS(superstep, aggregatedMetrics);
       }
+      for (MasterObserver observer : observers) {
+        observer.superstepMetricsUpdate(superstep, aggregatedMetrics);
+      }
     }
 
     if (LOG.isInfoEnabled()) {

--- a/giraph-core/src/main/java/org/apache/giraph/master/DefaultMasterObserver.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/DefaultMasterObserver.java
@@ -19,6 +19,7 @@
 package org.apache.giraph.master;
 
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
+import org.apache.giraph.metrics.AggregatedMetrics;
 
 /**
  * A no-op implementation of MasterObserver to make it easier for users.
@@ -51,4 +52,8 @@ public class DefaultMasterObserver implements MasterObserver {
 
   @Override
   public void postSuperstep(long superstep) { }
+
+  @Override
+  public void superstepMetricsUpdate(long superstep,
+      AggregatedMetrics aggregatedMetrics) { }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/master/MasterObserver.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/MasterObserver.java
@@ -19,6 +19,7 @@
 package org.apache.giraph.master;
 
 import org.apache.giraph.conf.ImmutableClassesGiraphConfigurable;
+import org.apache.giraph.metrics.AggregatedMetrics;
 
 /**
  * Observer for Master.
@@ -55,4 +56,13 @@ public interface MasterObserver extends ImmutableClassesGiraphConfigurable {
    * @param superstep The superstep number
    */
   void postSuperstep(long superstep);
+
+  /**
+   * Called after each superstep with aggregated metrics from workers
+   *
+   * @param superstep Supsertep number
+   * @param aggregatedMetrics Metrics
+   */
+  void superstepMetricsUpdate(
+      long superstep, AggregatedMetrics aggregatedMetrics);
 }

--- a/giraph-core/src/main/java/org/apache/giraph/metrics/ValueWithHostname.java
+++ b/giraph-core/src/main/java/org/apache/giraph/metrics/ValueWithHostname.java
@@ -23,7 +23,7 @@ package org.apache.giraph.metrics;
  *
  * @param <T> types of value (either long or double)
  */
-class ValueWithHostname<T extends Number> {
+public class ValueWithHostname<T extends Number> {
   /** long value we're holding */
   private T value;
   /** host associated with value */

--- a/giraph-core/src/main/java/org/apache/giraph/utils/JMapHistoDumper.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/JMapHistoDumper.java
@@ -21,6 +21,7 @@ package org.apache.giraph.utils;
 import org.apache.giraph.conf.GiraphConstants;
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
 import org.apache.giraph.master.MasterObserver;
+import org.apache.giraph.metrics.AggregatedMetrics;
 import org.apache.giraph.worker.WorkerObserver;
 import org.apache.log4j.Logger;
 
@@ -98,6 +99,10 @@ public class JMapHistoDumper implements MasterObserver, WorkerObserver {
 
   @Override
   public void postSuperstep(long superstep) { }
+
+  @Override
+  public void superstepMetricsUpdate(long superstep,
+      AggregatedMetrics aggregatedMetrics) { }
 
   @Override
   public void applicationFailed(Exception e) { }

--- a/giraph-core/src/main/java/org/apache/giraph/utils/LogVersions.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/LogVersions.java
@@ -19,6 +19,7 @@ package org.apache.giraph.utils;
 
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
 import org.apache.giraph.master.MasterObserver;
+import org.apache.giraph.metrics.AggregatedMetrics;
 import org.apache.giraph.worker.WorkerObserver;
 
 /**
@@ -55,4 +56,8 @@ public class LogVersions implements WorkerObserver, MasterObserver {
 
   @Override
   public void postSuperstep(long superstep) { }
+
+  @Override
+  public void superstepMetricsUpdate(long superstep,
+      AggregatedMetrics aggregatedMetrics) { }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/utils/ReactiveJMapHistoDumper.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/ReactiveJMapHistoDumper.java
@@ -22,6 +22,7 @@ import org.apache.giraph.conf.DefaultImmutableClassesGiraphConfigurable;
 import org.apache.giraph.conf.GiraphConstants;
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
 import org.apache.giraph.master.MasterObserver;
+import org.apache.giraph.metrics.AggregatedMetrics;
 import org.apache.giraph.worker.WorkerObserver;
 import org.apache.log4j.Logger;
 
@@ -109,6 +110,10 @@ public class ReactiveJMapHistoDumper extends
 
   @Override
   public void postSuperstep(long superstep) { }
+
+  @Override
+  public void superstepMetricsUpdate(long superstep,
+      AggregatedMetrics aggregatedMetrics) { }
 
   @Override
   public void applicationFailed(Exception e) { }


### PR DESCRIPTION
Summary: Pass superstep AggregatedMetrics to MasterObserver, to be able to analyze eg stragglers in jobs.