### PR TITLE
Instantiate OutEdges implementation with factory class

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -36,10 +36,12 @@ import org.apache.giraph.factories.ComputationFactory;
 import org.apache.giraph.factories.DefaultComputationFactory;
 import org.apache.giraph.factories.DefaultEdgeValueFactory;
 import org.apache.giraph.factories.DefaultMessageValueFactory;
+import org.apache.giraph.factories.DefaultOutEdgesFactory;
 import org.apache.giraph.factories.DefaultVertexIdFactory;
 import org.apache.giraph.factories.DefaultVertexValueFactory;
 import org.apache.giraph.factories.EdgeValueFactory;
 import org.apache.giraph.factories.MessageValueFactory;
+import org.apache.giraph.factories.OutEdgesFactory;
 import org.apache.giraph.factories.VertexIdFactory;
 import org.apache.giraph.factories.VertexValueFactory;
 import org.apache.giraph.graph.Computation;
@@ -198,6 +200,11 @@ public interface GiraphConstants {
       ClassConfOption.create("giraph.inputOutEdgesClass",
           ByteArrayEdges.class, OutEdges.class,
           "Vertex edges class to be used during edge input only - optional");
+  /** OutEdges factory class - optional */
+  ClassConfOption<OutEdgesFactory> OUT_EDGES_FACTORY_CLASS =
+      ClassConfOption.create("giraph.outEdgesFactoryClass",
+        DefaultOutEdgesFactory.class, OutEdgesFactory.class,
+          "OutEdges factory class - optional");
 
   /** Class for Master - optional */
   ClassConfOption<MasterCompute> MASTER_COMPUTE_CLASS =

--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -202,12 +202,12 @@ public interface GiraphConstants {
           ByteArrayEdges.class, OutEdges.class,
           "Vertex edges class to be used during edge input only - optional");
   /** OutEdges factory class - optional */
-  ClassConfOption<OutEdgesFactory> OUT_EDGES_FACTORY_CLASS =
+  ClassConfOption<OutEdgesFactory> VERTEX_EDGES_FACTORY_CLASS =
       ClassConfOption.create("giraph.outEdgesFactoryClass",
         DefaultOutEdgesFactory.class, OutEdgesFactory.class,
           "OutEdges factory class - optional");
   /** OutEdges for input factory class - optional */
-  ClassConfOption<OutEdgesFactory> INPUT_OUT_EDGES_FACTORY_CLASS =
+  ClassConfOption<OutEdgesFactory> INPUT_VERTEX_EDGES_FACTORY_CLASS =
       ClassConfOption.create("giraph.inputOutEdgesFactoryClass",
         DefaultInputOutEdgesFactory.class, OutEdgesFactory.class,
           "OutEdges for input factory class - optional");

--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -35,6 +35,7 @@ import org.apache.giraph.edge.OutEdges;
 import org.apache.giraph.factories.ComputationFactory;
 import org.apache.giraph.factories.DefaultComputationFactory;
 import org.apache.giraph.factories.DefaultEdgeValueFactory;
+import org.apache.giraph.factories.DefaultInputOutEdgesFactory;
 import org.apache.giraph.factories.DefaultMessageValueFactory;
 import org.apache.giraph.factories.DefaultOutEdgesFactory;
 import org.apache.giraph.factories.DefaultVertexIdFactory;
@@ -205,6 +206,11 @@ public interface GiraphConstants {
       ClassConfOption.create("giraph.outEdgesFactoryClass",
         DefaultOutEdgesFactory.class, OutEdgesFactory.class,
           "OutEdges factory class - optional");
+  /** OutEdges for input factory class - optional */
+  ClassConfOption<OutEdgesFactory> INPUT_OUT_EDGES_FACTORY_CLASS =
+      ClassConfOption.create("giraph.inputOutEdgesFactoryClass",
+        DefaultInputOutEdgesFactory.class, OutEdgesFactory.class,
+          "OutEdges for input factory class - optional");
 
   /** Class for Master - optional */
   ClassConfOption<MasterCompute> MASTER_COMPUTE_CLASS =

--- a/giraph-core/src/main/java/org/apache/giraph/conf/ImmutableClassesGiraphConfiguration.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/ImmutableClassesGiraphConfiguration.java
@@ -113,8 +113,10 @@ public class ImmutableClassesGiraphConfiguration<I extends WritableComparable,
   private Class<? extends Writable> mappingTargetClass = null;
   /** Value (IVEMM) Factories */
   private final ValueFactories<I, V, E> valueFactories;
-  /** {@link OutEdges} factory. */
+  /** Factory to create {@link OutEdges} for computation */
   private final OutEdgesFactory<I, E> outEdgesFactory;
+  /** Factory to create {@link OutEdges} for input */
+  private final OutEdgesFactory<I, E> inputOutEdgesFactory;
   /** Language values (IVEMM) are implemented in */
   private final PerGraphTypeEnum<Language> valueLanguages;
   /** Whether values (IVEMM) need Jython wrappers */
@@ -152,6 +154,7 @@ public class ImmutableClassesGiraphConfiguration<I extends WritableComparable,
     isStaticGraph = GiraphConstants.STATIC_GRAPH.get(this);
     valueFactories = new ValueFactories<I, V, E>(this);
     outEdgesFactory = OUT_EDGES_FACTORY_CLASS.newInstance(this);
+    inputOutEdgesFactory = INPUT_OUT_EDGES_FACTORY_CLASS.newInstance(this);
   }
 
   /**
@@ -1136,7 +1139,7 @@ public class ImmutableClassesGiraphConfiguration<I extends WritableComparable,
    * @return Instantiated user input OutEdges
    */
   public OutEdges<I, E> createInputOutEdges() {
-    return ReflectionUtils.newInstance(getInputOutEdgesClass(), this);
+    return inputOutEdgesFactory.newInstance();
   }
 
   /**

--- a/giraph-core/src/main/java/org/apache/giraph/conf/ImmutableClassesGiraphConfiguration.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/ImmutableClassesGiraphConfiguration.java
@@ -36,6 +36,7 @@ import org.apache.giraph.edge.ReusableEdge;
 import org.apache.giraph.factories.ComputationFactory;
 import org.apache.giraph.factories.EdgeValueFactory;
 import org.apache.giraph.factories.MessageValueFactory;
+import org.apache.giraph.factories.OutEdgesFactory;
 import org.apache.giraph.factories.ValueFactories;
 import org.apache.giraph.factories.VertexIdFactory;
 import org.apache.giraph.factories.VertexValueFactory;
@@ -112,6 +113,8 @@ public class ImmutableClassesGiraphConfiguration<I extends WritableComparable,
   private Class<? extends Writable> mappingTargetClass = null;
   /** Value (IVEMM) Factories */
   private final ValueFactories<I, V, E> valueFactories;
+  /** {@link OutEdges} factory. */
+  private final OutEdgesFactory<I, E> outEdgesFactory;
   /** Language values (IVEMM) are implemented in */
   private final PerGraphTypeEnum<Language> valueLanguages;
   /** Whether values (IVEMM) need Jython wrappers */
@@ -148,6 +151,7 @@ public class ImmutableClassesGiraphConfiguration<I extends WritableComparable,
         GiraphConstants.GRAPH_TYPES_NEEDS_WRAPPERS, conf);
     isStaticGraph = GiraphConstants.STATIC_GRAPH.get(this);
     valueFactories = new ValueFactories<I, V, E>(this);
+    outEdgesFactory = OUT_EDGES_FACTORY_CLASS.newInstance(this);
   }
 
   /**
@@ -1083,7 +1087,7 @@ public class ImmutableClassesGiraphConfiguration<I extends WritableComparable,
    * @return Instantiated user OutEdges
    */
   public OutEdges<I, E> createOutEdges() {
-    return ReflectionUtils.newInstance(getOutEdgesClass(), this);
+    return outEdgesFactory.newInstance();
   }
 
   /**

--- a/giraph-core/src/main/java/org/apache/giraph/conf/ImmutableClassesGiraphConfiguration.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/ImmutableClassesGiraphConfiguration.java
@@ -153,8 +153,8 @@ public class ImmutableClassesGiraphConfiguration<I extends WritableComparable,
         GiraphConstants.GRAPH_TYPES_NEEDS_WRAPPERS, conf);
     isStaticGraph = GiraphConstants.STATIC_GRAPH.get(this);
     valueFactories = new ValueFactories<I, V, E>(this);
-    outEdgesFactory = OUT_EDGES_FACTORY_CLASS.newInstance(this);
-    inputOutEdgesFactory = INPUT_OUT_EDGES_FACTORY_CLASS.newInstance(this);
+    outEdgesFactory = VERTEX_EDGES_FACTORY_CLASS.newInstance(this);
+    inputOutEdgesFactory = INPUT_VERTEX_EDGES_FACTORY_CLASS.newInstance(this);
   }
 
   /**

--- a/giraph-core/src/main/java/org/apache/giraph/factories/DefaultInputOutEdgesFactory.java
+++ b/giraph-core/src/main/java/org/apache/giraph/factories/DefaultInputOutEdgesFactory.java
@@ -26,13 +26,13 @@ import org.apache.hadoop.io.WritableComparable;
 
 /**
  * Default factory class for creating {@link OutEdges} instances to be used
- * during computation. This factory simply creates an instance of the
+ * during input. This factory simply creates an instance of the
  * {@link OutEdges} class set in the configuration.
  *
  * @param <I> Vertex ID type.
  * @param <E> Edge value type.
  */
-public class DefaultOutEdgesFactory<I extends WritableComparable,
+public class DefaultInputOutEdgesFactory<I extends WritableComparable,
   E extends Writable> implements OutEdgesFactory<I, E>,
   GiraphConfigurationSettable {
   /** Configuration */
@@ -45,6 +45,6 @@ public class DefaultOutEdgesFactory<I extends WritableComparable,
 
   @Override
   public OutEdges<I, E> newInstance() {
-    return ReflectionUtils.newInstance(conf.getOutEdgesClass(), conf);
+    return ReflectionUtils.newInstance(conf.getInputOutEdgesClass(), conf);
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/factories/DefaultOutEdgesFactory.java
+++ b/giraph-core/src/main/java/org/apache/giraph/factories/DefaultOutEdgesFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.giraph.factories;
+
+import org.apache.giraph.conf.GiraphConfigurationSettable;
+import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
+import org.apache.giraph.edge.OutEdges;
+import org.apache.giraph.utils.ReflectionUtils;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+
+/**
+ * Default factory class for creating {@link OutEdges} instances. This factory
+ * simply creates an instance of the {@link OutEdges} class set in the
+ * configuration.
+ *
+ * @param <I> Vertex ID type.
+ * @param <E> Edge value type.
+ */
+public class DefaultOutEdgesFactory<I extends WritableComparable,
+  E extends Writable> implements OutEdgesFactory<I, E>,
+  GiraphConfigurationSettable {
+  /**
+   * Configuration
+   */
+  private ImmutableClassesGiraphConfiguration<I, ?, E> conf;
+
+  @Override
+  public void setConf(ImmutableClassesGiraphConfiguration conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public OutEdges<I, E> newInstance() {
+    return ReflectionUtils.newInstance(conf.getOutEdgesClass(), conf);
+  }
+}

--- a/giraph-core/src/main/java/org/apache/giraph/factories/OutEdgesFactory.java
+++ b/giraph-core/src/main/java/org/apache/giraph/factories/OutEdgesFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.giraph.factories;
+
+import org.apache.giraph.edge.OutEdges;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+
+import java.io.Serializable;
+
+/**
+ * Factory interface for creating {@link OutEdges} instances.
+ *
+ * @param <I> Vertex ID type.
+ * @param <E> Edge value type.
+ */
+public interface OutEdgesFactory<I extends WritableComparable,
+  E extends Writable> extends Serializable {
+
+  /**
+   * Creates a new {@link OutEdges instance}.
+   *
+   * @return {@link OutEdges} instance.
+   */
+  OutEdges<I, E> newInstance();
+}


### PR DESCRIPTION
Sometimes the instantiation of an OutEdges implementation might have large overhead, e.g. if it access the configuration.  Instead of creating it directly, introduce a factory class that can be instantiated once. 

https://issues.apache.org/jira/browse/GIRAPH-1168

Testing:
- mvn clean install
- internal unit tests & snapshot tests
- run with large job with custom OutEdges factory.