### PR TITLE
Add logging for out-of-core

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/ooc/data/DiskBackedPartitionStore.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/data/DiskBackedPartitionStore.java
@@ -368,7 +368,7 @@ public class DiskBackedPartitionStore<I extends WritableComparable,
           partitionStore.getPartitionEdgeCount(partitionId));
       Partition<I, V, E> partition =
           partitionStore.removePartition(partitionId);
-      LOG.info("Offloading partition " + partition + " DataIndex[" + index + "]");
+      LOG.debug("Offloading partition " + partition + " DataIndex[" + index + "]");
       index.addIndex(DataIndex.TypeIndexEntry.PARTITION_VERTICES);
       OutOfCoreDataAccessor.DataOutputWrapper outputWrapper =
           dataAccessor.prepareOutput(ioThreadId, index.copy(), false);

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/data/DiskBackedPartitionStore.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/data/DiskBackedPartitionStore.java
@@ -244,6 +244,9 @@ public class DiskBackedPartitionStore<I extends WritableComparable,
     I id = conf.createVertexId();
     id.readFields(in);
     Vertex<I, V, E> v = partition.getVertex(id);
+    checkNotNull(v, "Vertex with ID " + id + " not found in partition " +
+      partition.getId() + " which has " + partition.getVertexCount() +
+      " vertices and " + partition.getEdgeCount() + " edges.");
     OutEdges<I, E> edges = (OutEdges<I, E>) v.getEdges();
     edges.readFields(in);
     partition.saveVertex(v);
@@ -365,6 +368,7 @@ public class DiskBackedPartitionStore<I extends WritableComparable,
           partitionStore.getPartitionEdgeCount(partitionId));
       Partition<I, V, E> partition =
           partitionStore.removePartition(partitionId);
+      LOG.info("Offloading partition " + partition + " DataIndex[" + index + "]");
       index.addIndex(DataIndex.TypeIndexEntry.PARTITION_VERTICES);
       OutOfCoreDataAccessor.DataOutputWrapper outputWrapper =
           dataAccessor.prepareOutput(ioThreadId, index.copy(), false);


### PR DESCRIPTION
Adding some debugging information when reading a partition from disk fails.

https://issues.apache.org/jira/browse/GIRAPH-1170