### PR TITLE
GIRAPH-1171: Collect stats about how long it took to process each partition

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
@@ -985,7 +985,8 @@ public class BspServiceMaster<I extends WritableComparable,
         printAggregatedMetricsToHDFS(superstep, aggregatedMetrics);
       }
       for (MasterObserver observer : observers) {
-        observer.superstepMetricsUpdate(superstep, aggregatedMetrics);
+        observer.superstepMetricsUpdate(
+            superstep, aggregatedMetrics, allPartitionStatsList);
       }
     }
 

--- a/giraph-core/src/main/java/org/apache/giraph/master/DefaultMasterObserver.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/DefaultMasterObserver.java
@@ -20,6 +20,9 @@ package org.apache.giraph.master;
 
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
 import org.apache.giraph.metrics.AggregatedMetrics;
+import org.apache.giraph.partition.PartitionStats;
+
+import java.util.List;
 
 /**
  * A no-op implementation of MasterObserver to make it easier for users.
@@ -55,5 +58,6 @@ public class DefaultMasterObserver implements MasterObserver {
 
   @Override
   public void superstepMetricsUpdate(long superstep,
-      AggregatedMetrics aggregatedMetrics) { }
+      AggregatedMetrics aggregatedMetrics,
+      List<PartitionStats> partitionStatsList) { }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/master/MasterObserver.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/MasterObserver.java
@@ -20,6 +20,9 @@ package org.apache.giraph.master;
 
 import org.apache.giraph.conf.ImmutableClassesGiraphConfigurable;
 import org.apache.giraph.metrics.AggregatedMetrics;
+import org.apache.giraph.partition.PartitionStats;
+
+import java.util.List;
 
 /**
  * Observer for Master.
@@ -62,7 +65,9 @@ public interface MasterObserver extends ImmutableClassesGiraphConfigurable {
    *
    * @param superstep Supsertep number
    * @param aggregatedMetrics Metrics
+   * @param partitionStatsList List of partition stats
    */
   void superstepMetricsUpdate(
-      long superstep, AggregatedMetrics aggregatedMetrics);
+      long superstep, AggregatedMetrics aggregatedMetrics,
+      List<PartitionStats> partitionStatsList);
 }

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/data/DiskBackedPartitionStore.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/data/DiskBackedPartitionStore.java
@@ -368,7 +368,8 @@ public class DiskBackedPartitionStore<I extends WritableComparable,
           partitionStore.getPartitionEdgeCount(partitionId));
       Partition<I, V, E> partition =
           partitionStore.removePartition(partitionId);
-      LOG.debug("Offloading partition " + partition + " DataIndex[" + index + "]");
+      LOG.debug(
+          "Offloading partition " + partition + " DataIndex[" + index + "]");
       index.addIndex(DataIndex.TypeIndexEntry.PARTITION_VERTICES);
       OutOfCoreDataAccessor.DataOutputWrapper outputWrapper =
           dataAccessor.prepareOutput(ioThreadId, index.copy(), false);

--- a/giraph-core/src/main/java/org/apache/giraph/partition/PartitionStats.java
+++ b/giraph-core/src/main/java/org/apache/giraph/partition/PartitionStats.java
@@ -40,6 +40,13 @@ public class PartitionStats implements Writable {
   private long messagesSentCount = 0;
   /** Message byetes sent from this partition */
   private long messageBytesSentCount = 0;
+  /**
+   * How long did compute take on this partition
+   * (excluding time spent in GC) (TODO and waiting on open requests)
+   */
+  private long computeMs;
+  /** Hostname and id of worker owning this partition */
+  private String workerHostnameId;
 
   /**
    * Default constructor for reflection.
@@ -55,19 +62,22 @@ public class PartitionStats implements Writable {
    * @param edgeCount Edge count.
    * @param messagesSentCount Number of messages sent
    * @param messageBytesSentCount Number of message bytes sent
+   * @param workerHostnameId Hostname and id of worker owning this partition
    */
   public PartitionStats(int partitionId,
       long vertexCount,
       long finishedVertexCount,
       long edgeCount,
       long messagesSentCount,
-      long messageBytesSentCount) {
+      long messageBytesSentCount,
+      String workerHostnameId) {
     this.partitionId = partitionId;
     this.vertexCount = vertexCount;
     this.finishedVertexCount = finishedVertexCount;
     this.edgeCount = edgeCount;
     this.messagesSentCount = messagesSentCount;
     this.messageBytesSentCount = messageBytesSentCount;
+    this.workerHostnameId = workerHostnameId;
   }
 
   /**
@@ -174,6 +184,18 @@ public class PartitionStats implements Writable {
     return messageBytesSentCount;
   }
 
+  public long getComputeMs() {
+    return computeMs;
+  }
+
+  public void setComputeMs(long computeMs) {
+    this.computeMs = computeMs;
+  }
+
+  public String getWorkerHostnameId() {
+    return workerHostnameId;
+  }
+
   @Override
   public void readFields(DataInput input) throws IOException {
     partitionId = input.readInt();
@@ -182,6 +204,8 @@ public class PartitionStats implements Writable {
     edgeCount = input.readLong();
     messagesSentCount = input.readLong();
     messageBytesSentCount = input.readLong();
+    computeMs = input.readLong();
+    workerHostnameId = input.readUTF();
   }
 
   @Override
@@ -192,6 +216,8 @@ public class PartitionStats implements Writable {
     output.writeLong(edgeCount);
     output.writeLong(messagesSentCount);
     output.writeLong(messageBytesSentCount);
+    output.writeLong(computeMs);
+    output.writeUTF(workerHostnameId);
   }
 
   @Override
@@ -199,6 +225,7 @@ public class PartitionStats implements Writable {
     return "(id=" + partitionId + ",vtx=" + vertexCount + ",finVtx=" +
         finishedVertexCount + ",edges=" + edgeCount + ",msgsSent=" +
         messagesSentCount + ",msgBytesSent=" +
-          messageBytesSentCount + ")";
+        messageBytesSentCount + ",computeMs=" + computeMs +
+        ")";
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/utils/JMapHistoDumper.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/JMapHistoDumper.java
@@ -22,8 +22,11 @@ import org.apache.giraph.conf.GiraphConstants;
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
 import org.apache.giraph.master.MasterObserver;
 import org.apache.giraph.metrics.AggregatedMetrics;
+import org.apache.giraph.partition.PartitionStats;
 import org.apache.giraph.worker.WorkerObserver;
 import org.apache.log4j.Logger;
+
+import java.util.List;
 
 /**
  * An observer for both worker and master that periodically dumps the memory
@@ -102,7 +105,8 @@ public class JMapHistoDumper implements MasterObserver, WorkerObserver {
 
   @Override
   public void superstepMetricsUpdate(long superstep,
-      AggregatedMetrics aggregatedMetrics) { }
+      AggregatedMetrics aggregatedMetrics,
+      List<PartitionStats> partitionStatsList) { }
 
   @Override
   public void applicationFailed(Exception e) { }

--- a/giraph-core/src/main/java/org/apache/giraph/utils/LogVersions.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/LogVersions.java
@@ -20,7 +20,10 @@ package org.apache.giraph.utils;
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
 import org.apache.giraph.master.MasterObserver;
 import org.apache.giraph.metrics.AggregatedMetrics;
+import org.apache.giraph.partition.PartitionStats;
 import org.apache.giraph.worker.WorkerObserver;
+
+import java.util.List;
 
 /**
  * Logs versions of Giraph dependencies on job start.
@@ -59,5 +62,6 @@ public class LogVersions implements WorkerObserver, MasterObserver {
 
   @Override
   public void superstepMetricsUpdate(long superstep,
-      AggregatedMetrics aggregatedMetrics) { }
+      AggregatedMetrics aggregatedMetrics,
+      List<PartitionStats> partitionStatsList) { }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/utils/ReactiveJMapHistoDumper.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/ReactiveJMapHistoDumper.java
@@ -23,8 +23,11 @@ import org.apache.giraph.conf.GiraphConstants;
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
 import org.apache.giraph.master.MasterObserver;
 import org.apache.giraph.metrics.AggregatedMetrics;
+import org.apache.giraph.partition.PartitionStats;
 import org.apache.giraph.worker.WorkerObserver;
 import org.apache.log4j.Logger;
+
+import java.util.List;
 
 /**
  * An observer for both worker and master that periodically checks if available
@@ -113,7 +116,8 @@ public class ReactiveJMapHistoDumper extends
 
   @Override
   public void superstepMetricsUpdate(long superstep,
-      AggregatedMetrics aggregatedMetrics) { }
+      AggregatedMetrics aggregatedMetrics,
+      List<PartitionStats> partitionStatsList) { }
 
   @Override
   public void applicationFailed(Exception e) { }

--- a/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
@@ -608,7 +608,9 @@ else[HADOOP_NON_SECURE]*/
               partitionStore.getPartitionVertexCount(partitionId),
               0,
               partitionStore.getPartitionEdgeCount(partitionId),
-              0, 0);
+              0,
+              0,
+              workerInfo.getHostnameId());
       partitionStatsList.add(partitionStats);
     }
     workerGraphPartitioner.finalizePartitionStats(


### PR DESCRIPTION
In order to make it easier to analyze whether there are some vertices in the graph which slow down the computation, or processing times of partitions is imbalanced, expose the stats about how long it took for each partition to be processed.