### PR TITLE
GIRAPH-1172 Removed dependency com.google.code.findbugs:annotations

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -96,4 +96,12 @@
       On the other hand, Kryo needs lambdas to be Serializable to work. -->
     <Bug pattern="SE_BAD_FIELD,SE_COMPARATOR_SHOULD_BE_SERIALIZABLE,SE_NO_SERIALVERSIONID" />
   </Match>
+  <Match>
+    <Class name="org.apache.giraph.block_app.library.gc.WorkerGCPiece"/>
+    <Bug pattern="DM_GC"/>
+  </Match>
+  <Match>
+    <Class name="org.apache.giraph.object.MultiSizedReusable"/>
+    <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
+  </Match>
 </FindBugsFilter>

--- a/giraph-block-app/pom.xml
+++ b/giraph-block-app/pom.xml
@@ -110,10 +110,6 @@ under the License.
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
 
     <!-- runtime dependency -->
     <dependency>

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/library/gc/WorkerGCPiece.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/library/gc/WorkerGCPiece.java
@@ -23,8 +23,6 @@ import org.apache.giraph.types.NoMessage;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 /**
  * Dummy piece to hint System.gc()
  */
@@ -32,7 +30,6 @@ public class WorkerGCPiece extends PieceWithWorkerContext<WritableComparable,
     Writable, Writable, NoMessage, Object, NoMessage, Object>  {
 
   @Override
-  @SuppressFBWarnings(value = "DM_GC")
   public void workerContextSend(
       BlockWorkerContextSendApi<WritableComparable, NoMessage> workerContextApi,
       Object executionStage,

--- a/giraph-block-app/src/main/java/org/apache/giraph/object/MultiSizedReusable.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/object/MultiSizedReusable.java
@@ -25,8 +25,6 @@ import org.apache.giraph.types.ops.collections.BasicSet;
 
 import com.google.common.base.Preconditions;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 /**
  * Holds reusable objects of multiple sizes.
  * Example usecase, is when we need a hashmap - that we will insert and iterate
@@ -43,7 +41,6 @@ public class MultiSizedReusable<T> implements Int2ObjFunction<T> {
   private final Int2ObjFunction<T> createSized;
   private final Consumer<T> init;
   @SuppressWarnings("unchecked")
-  @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
   private final transient T[] holder = (T[]) new Object[Integer.SIZE];
 
   // No-arg constructor Kryo can call to initialize holder

--- a/giraph-core/pom.xml
+++ b/giraph-core/pom.xml
@@ -476,7 +476,11 @@ under the License.
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stephenc.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,7 @@ under the License.
     <dep.fasterxml-jackson.version>2.1.2</dep.fasterxml-jackson.version>
     <dep.fastutil.version>6.5.4</dep.fastutil.version>
     <dep.google.findbugs.version>2.0.2</dep.google.findbugs.version>
+    <dep.stephenc-findbugs.version>1.3.9-1</dep.stephenc-findbugs.version>
     <dep.guava.version>18.0</dep.guava.version>
     <dep.hbase.version>0.94.16</dep.hbase.version>
     <dep.hcatalog.version>0.5.0-incubating</dep.hcatalog.version>
@@ -635,12 +636,8 @@ under the License.
                   <exclude>com.google.collections:google-collections</exclude>
                   <!-- but not the badly numbered ones... -->
                   <exclude>com.google.guava:guava</exclude>
-                  <!-- Clashes with com.google.code.findbugs:annotations and having both jars -->
-                  <!-- as a dependency then clashes with the dependency checker (because it   -->
-                  <!-- is not very good at handling annotations). Use the annotations jar     -->
-                  <!-- instead which has all jsr305 annotations and the additional findbugs   -->
-                  <!-- stuff. -->
-                  <exclude>com.google.code.findbugs:jsr305</exclude>
+                  <!-- com.google.code.findbugs:annotations is LGPL.  Use com.github.stephenc.findbugs:findbugs-annotations instead.  -->
+                  <exclude>com.google.code.findbugs:annotations</exclude>
                   <!-- Use the official version at javax.servlet:javax.servlet-api -->
                   <exclude>org.eclipse.jetty.orbit:javax.servlet</exclude>
                   <!-- Renamed airlift modules -->
@@ -1541,8 +1538,13 @@ under the License.
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
-        <artifactId>annotations</artifactId>
+        <artifactId>jsr305</artifactId>
         <version>${dep.google.findbugs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.stephenc.findbugs</groupId>
+        <artifactId>findbugs-annotations</artifactId>
+        <version>${dep.stephenc-findbugs.version}</version>
       </dependency>
       <dependency>
         <groupId>com.tinkerpop.blueprints</groupId>
@@ -1714,6 +1716,10 @@ under the License.
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1732,6 +1738,10 @@ under the License.
           <exclusion>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-all</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1756,6 +1766,10 @@ under the License.
           <exclusion>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Replaced `com.google.code.findbugs:annotations:2.0.2` with `com.github.stephenc.findbugs:findbugs-annotations:1.3.9-1` and `com.google.code.findbugs:jsr305:2.0.2`.

Had to remove a couple annotations that don't exist in the older version of the drop-in replacement.  There is a newer version of com.github.stephenc.findbugs:findbugs-annotations, but it hasn't been uploaded to maven central for some reason.  Moved usage of those annotations to the findbugs-exclude.xml file.