### PR TITLE
Calculate edge count in log line only if necessary

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/ooc/data/DiskBackedPartitionStore.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/data/DiskBackedPartitionStore.java
@@ -244,9 +244,11 @@ public class DiskBackedPartitionStore<I extends WritableComparable,
     I id = conf.createVertexId();
     id.readFields(in);
     Vertex<I, V, E> v = partition.getVertex(id);
-    checkNotNull(v, "Vertex with ID " + id + " not found in partition " +
-      partition.getId() + " which has " + partition.getVertexCount() +
-      " vertices and " + partition.getEdgeCount() + " edges.");
+    if (v == null) {
+      throw new IllegalStateException("Vertex with ID " + id + " not found in partition " +
+        partition.getId() + " which has " + partition.getVertexCount() +
+        " vertices and " + partition.getEdgeCount() + " edges.");
+    }
     OutEdges<I, E> edges = (OutEdges<I, E>) v.getEdges();
     edges.readFields(in);
     partition.saveVertex(v);


### PR DESCRIPTION
Calling `partition.getEdgeCount()` iteration on all the vertices of the partition, which can be expensive. The expression inside `checkNotNull` is always evaluated, making this expensive. This constructs the string only if necessary.

https://issues.apache.org/jira/browse/GIRAPH-1175

Tests:
- mvn clean install
- run test jobs