### PR TITLE
Improve ZK logging in BspServiceMaster

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
@@ -1299,6 +1299,7 @@ public class BspServiceMaster<I extends WritableComparable,
     String workerInfoHealthyPath =
         getWorkerInfoHealthyPath(getApplicationAttempt(), getSuperstep());
     List<String> finishedHostnameIdList = new ArrayList<>();
+    List<String> tmpFinishedHostnameIdList;
     long nextInfoMillis = System.currentTimeMillis();
     final int defaultTaskTimeoutMsec = 10 * 60 * 1000;  // from TaskTracker
     final int waitBetweenLogInfoMsec = 30 * 1000;
@@ -1311,7 +1312,7 @@ public class BspServiceMaster<I extends WritableComparable,
     while (true) {
       if (! logInfoOnlyRun) {
         try {
-          finishedHostnameIdList =
+          tmpFinishedHostnameIdList =
               getZkExt().getChildrenExt(finishedWorkerPath,
                                         true,
                                         false,
@@ -1326,14 +1327,16 @@ public class BspServiceMaster<I extends WritableComparable,
                   "children of " + finishedWorkerPath, e);
         }
         if (LOG.isDebugEnabled()) {
-          LOG.debug("barrierOnWorkerList: Got finished worker list = " +
-                        finishedHostnameIdList + ", size = " +
-                        finishedHostnameIdList.size() +
-                        ", worker list = " +
-                        workerInfoList + ", size = " +
-                        workerInfoList.size() +
+          // Log the names of the new workers that have finished since last time
+          Set<String> newFinishedHostnames = Sets.difference(
+            Sets.newHashSet(tmpFinishedHostnameIdList),
+            Sets.newHashSet(finishedHostnameIdList));
+          LOG.debug("barrierOnWorkerList: Got new finished worker list = " +
+                        newFinishedHostnames + ", size = " +
+                        newFinishedHostnames.size() +
                         " from " + finishedWorkerPath);
         }
+        finishedHostnameIdList = tmpFinishedHostnameIdList;
       }
 
       if (LOG.isInfoEnabled() &&


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GIRAPH-1194

Every time there is a new event, like workers finishing the superstep, BspServiceMaster logs the entire list of workers that have finishes. This is too verbose. We should print the new workers each time.

Tests:
- mvn clean install -DskipTest
- run job and verify logging
