### PR TITLE
Fixed out-dated maven command in README

### DIFF
--- a/README
+++ b/README
@@ -62,7 +62,7 @@ Secure Hadoop versions:
 
 - Apache Hadoop 3.0.0-SNAPSHOT
 
-  You may tell maven to use this version with "mvn -Phadoop_trunk <goals>".
+  You may tell maven to use this version with "mvn -Phadoop_snapshot <goals>".
 
 Unsecure Hadoop versions:
 


### PR DESCRIPTION
Fixed Maven command in README for compatibility with Hadoop 3.0.0-SNAPSHOT