### PR TITLE
Fixes Incorrect Logging Statement on #255 in GiraphYarnClient

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/yarn/GiraphYarnClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/yarn/GiraphYarnClient.java
@@ -252,7 +252,7 @@ public class GiraphYarnClient {
     }
     if (giraphMem > maxCapacity) {
       LOG.info("Giraph's request of heap MB per-task is more than the " +
-        "minimum; downgrading Giraph to" + maxCapacity + "MB.");
+        "maximum; downgrading Giraph to" + maxCapacity + "MB.");
       giraphMem = maxCapacity;
     }
     /*if (giraphMem < minCapacity) { //TODO:


### PR DESCRIPTION
Summary :

In-case, Yarn-Heap-Size passed in Giraph Configuration exceeds max available capacity, we downgrade its value to max capacity (Lines #253-#257). 

Currently, the logger message associated with this conditional statement incorrectly states "minimum" instead of "maximum", which is misleading. This change fixes it.