### PR TITLE
Fix BspServiceMaster bug

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
@@ -1379,9 +1379,15 @@ public class BspServiceMaster<I extends WritableComparable,
 
       // Wait for a signal or timeout
       boolean eventTriggered = event.waitMsecs(eventLoopTimeout);
+
+      // If the event was triggered, we reset it. In the next loop run, we will
+      // read ZK to get the new hosts.
+      if (eventTriggered) {
+        event.reset();
+      }
+
       long elapsedTimeSinceRegularRunMsec = System.currentTimeMillis() -
           lastRegularRunTimeMsec;
-      event.reset();
       getContext().progress();
 
       if (eventTriggered ||


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GIRAPH-1201

Occasionally, BspServiceMaster fails to detect that a worker finished a superstep (e.g. input superstep, or a compute supestep). As a result, the job may get stuck as the master keeps waiting for all workers to finish.

While this is hard to reproduce, this fixes a potential cause for this.

Tests
- Unit tests
- Internal snapshot tests
- Ran large job