### PR TITLE
Add BVEdges, IndexedBitArrayEdges, and IntervalResidualEdges implementations

### DIFF
--- a/giraph-core/pom.xml
+++ b/giraph-core/pom.xml
@@ -522,6 +522,10 @@ under the License.
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil</artifactId>
     </dependency>
+ 	<dependency>
+	  <groupId>it.unimi.dsi</groupId>
+      <artifactId>webgraph</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>

--- a/giraph-core/pom.xml
+++ b/giraph-core/pom.xml
@@ -519,6 +519,10 @@ under the License.
       <artifactId>base64</artifactId>
     </dependency>
     <dependency>
+        <groupId>it.unimi.dsi</groupId>
+        <artifactId>dsiutils</artifactId>
+      </dependency>
+    <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil</artifactId>
     </dependency>

--- a/giraph-core/src/main/java/org/apache/giraph/edge/BVEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/BVEdges.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.giraph.edge;
 
 import it.unimi.dsi.bits.Fast;

--- a/giraph-core/src/main/java/org/apache/giraph/edge/BVEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/BVEdges.java
@@ -46,6 +46,15 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.UnmodifiableIterator;
 
+/**
+ * Implementation of {@link OutEdges} with int ids and null edge values, backed
+ * by the BVEdges structure proposed in "Panagiotis Liakos, Katia
+ * Papakonstantinopoulou, Alex Delis: Realizing Memory-Optimized Distributed
+ * Graph Processing. IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018)". Note:
+ * this implementation is optimized for space usage for graphs exhibiting the
+ * locality of reference property, but edge addition and
+ * removals are expensive. Parallel edges are not allowed.
+ */
 public class BVEdges extends ConfigurableOutEdges<IntWritable, NullWritable>
 		implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {
 

--- a/giraph-core/src/main/java/org/apache/giraph/edge/BVEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/BVEdges.java
@@ -48,10 +48,13 @@ import com.google.common.collect.UnmodifiableIterator;
 
 /**
  * Implementation of {@link OutEdges} with int ids and null edge values, backed
- * by the BVEdges structure proposed in "Panagiotis Liakos, Katia
- * Papakonstantinopoulou, Alex Delis: Realizing Memory-Optimized Distributed
- * Graph Processing. IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018)". Note:
- * this implementation is optimized for space usage for graphs exhibiting the
+ * by the BVEdges structure proposed in:
+ * 
+ * Panagiotis Liakos, Katia Papakonstantinopoulou, Alex Delis:
+ * Realizing Memory-Optimized Distributed Graph Processing.
+ * IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018).
+ * 
+ * Note: this implementation is optimized for space usage for graphs exhibiting the
  * locality of reference property, but edge addition and
  * removals are expensive. Parallel edges are not allowed.
  */

--- a/giraph-core/src/main/java/org/apache/giraph/edge/BVEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/BVEdges.java
@@ -35,13 +35,12 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.stream.StreamSupport;
 
 import org.apache.giraph.utils.Trimmable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.NullWritable;
-import org.weakref.jmx.com.google.common.collect.Iterators;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.UnmodifiableIterator;
@@ -49,389 +48,446 @@ import com.google.common.collect.UnmodifiableIterator;
 /**
  * Implementation of {@link OutEdges} with int ids and null edge values, backed
  * by the BVEdges structure proposed in:
- * 
+ *
  * Panagiotis Liakos, Katia Papakonstantinopoulou, Alex Delis:
  * Realizing Memory-Optimized Distributed Graph Processing.
  * IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018).
- * 
- * Note: this implementation is optimized for space usage for graphs exhibiting the
- * locality of reference property, but edge addition and
- * removals are expensive. Parallel edges are not allowed.
+ *
+ * Note: this implementation is optimized for space usage for graphs exhibiting
+ * the locality of reference property, but edge addition and removals are
+ * expensive. Parallel edges are not allowed.
  */
 public class BVEdges extends ConfigurableOutEdges<IntWritable, NullWritable>
-		implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {
+    implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {
 
-	/** Serialized Intervals and Residuals */
-	private byte[] intervalsAndResiduals;
-	/** Number of edges. */
-	private int size;
+  /** Serialized Intervals and Residuals */
+  private byte[] intervalsAndResiduals;
+  /** Number of edges. */
+  private int size;
 
-	@Override
-	public void initialize(Iterable<Edge<IntWritable, NullWritable>> edges) {
-		compress(StreamSupport.stream(edges.spliterator(), false).map(Edge::getTargetVertexId)
-				.mapToInt(IntWritable::get).toArray());
-	}
+  @Override
+  public void initialize(Iterable<Edge<IntWritable, NullWritable>> edges) {
+    IntArrayList edgesList = new IntArrayList();
+    for (Iterator<Edge<IntWritable, NullWritable>> iter = edges.iterator(); iter
+        .hasNext();) {
+      edgesList.add(iter.next().getTargetVertexId().get());
+    }
+    compress(Arrays.copyOfRange(edgesList.elements(), 0, edgesList.size()));
+  }
 
-	@Override
-	public void initialize(int capacity) {
-		size = 0;
-		intervalsAndResiduals = null;
-	}
+  @Override
+  public void initialize(int capacity) {
+    size = 0;
+    intervalsAndResiduals = null;
+  }
 
-	@Override
-	public void initialize() {
-		size = 0;
-		intervalsAndResiduals = null;
-	}
+  @Override
+  public void initialize() {
+    size = 0;
+    intervalsAndResiduals = null;
+  }
 
-	@Override
-	public void add(Edge<IntWritable, NullWritable> edge) {
-		// Note that ths is very expensive (decompresses all edges and recompresses them again).
-		compress(StreamSupport
-				.stream(((Iterable<Edge<IntWritable, NullWritable>>) () -> Iterators.concat(this.iterator(),
-						ImmutableSet.of(edge).iterator())).spliterator(), false)
-				.map(Edge::getTargetVertexId).mapToInt(IntWritable::get).sorted().toArray());
-	}
+  @Override
+  public void add(Edge<IntWritable, NullWritable> edge) {
+    // Note that this is very expensive (decompresses all edges and recompresses
+    // them again).
+    IntArrayList edgesList = new IntArrayList();
+    for (Iterator<Edge<IntWritable, NullWritable>> iter = this.iterator(); iter
+        .hasNext();) {
+      edgesList.add(iter.next().getTargetVertexId().get());
+    }
+    edgesList.add(edge.getTargetVertexId().get());
+    compress(Arrays.copyOfRange(edgesList.elements(), 0, edgesList.size()));
+  }
 
-	@Override
-	public void remove(IntWritable targetVertexId) {
-		// Note that this is very expensive (decompresses all edges and recompresses them again).
-		initialize(Iterables.filter(this, edge -> !edge.getTargetVertexId().equals(targetVertexId)));
-	}
+  @Override
+  public void remove(IntWritable targetVertexId) {
+    // Note that this is very expensive (decompresses all edges and recompresses
+    // them again).
+    final int id = targetVertexId.get();
+    initialize(Iterables.filter(this,
+        new Predicate<Edge<IntWritable, NullWritable>>() {
+          @Override
+          public boolean apply(Edge<IntWritable, NullWritable> edge) {
+            return edge.getTargetVertexId().get() != id;
+          }
+        }));
+  }
 
-	@Override
-	public int size() {
-		return size;
-	}
-	
-	@Override
-	public Iterator<Edge<IntWritable, NullWritable>> iterator() {
-		if (size == 0) {
-			return ImmutableSet.<Edge<IntWritable, NullWritable>>of().iterator();
-		} else {
-			return new BVEdgesIterator();
-		}
-	}
+  @Override
+  public int size() {
+    return size;
+  }
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		size = in.readInt();
-		int intervalResidualEdgesBytesUsed = in.readInt();
-		if (intervalResidualEdgesBytesUsed > 0) {
-			// Only create a new buffer if the old one isn't big enough
-			if (intervalsAndResiduals == null || intervalResidualEdgesBytesUsed > intervalsAndResiduals.length) {
-				intervalsAndResiduals = new byte[intervalResidualEdgesBytesUsed];
-			}
-			in.readFully(intervalsAndResiduals, 0, intervalResidualEdgesBytesUsed);
-		}
-	}
+  @Override
+  public Iterator<Edge<IntWritable, NullWritable>> iterator() {
+    if (size == 0) {
+      return ImmutableSet.<Edge<IntWritable, NullWritable>>of().iterator();
+    } else {
+      return new BVEdgesIterator();
+    }
+  }
 
-	@Override
-	public void write(DataOutput out) throws IOException {
-		out.writeInt(size);
-		out.writeInt(intervalsAndResiduals.length);
-		if (intervalsAndResiduals.length > 0) {
-			out.write(intervalsAndResiduals, 0, intervalsAndResiduals.length);
-		}
-	}
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    size = in.readInt();
+    int intervalResidualEdgesBytesUsed = in.readInt();
+    if (intervalResidualEdgesBytesUsed > 0) {
+      // Only create a new buffer if the old one isn't big enough
+      if (intervalsAndResiduals == null ||
+          intervalResidualEdgesBytesUsed > intervalsAndResiduals.length) {
+        intervalsAndResiduals = new byte[intervalResidualEdgesBytesUsed];
+      }
+      in.readFully(intervalsAndResiduals, 0, intervalResidualEdgesBytesUsed);
+    }
+  }
 
-	@Override
-	public void trim() {
-		// Nothing to do
-	}
+  @Override
+  public void write(DataOutput out) throws IOException {
+    out.writeInt(size);
+    out.writeInt(intervalsAndResiduals.length);
+    if (intervalsAndResiduals.length > 0) {
+      out.write(intervalsAndResiduals, 0, intervalsAndResiduals.length);
+    }
+  }
 
+  @Override
+  public void trim() {
+    // Nothing to do
+  }
 
-	/**
-	 * Receives an integer array of successors and compresses them in the
-	 * intervalsAndResiduals byte array
-	 * 
-	 * @param edgesArray an integer array of successors
-	 */
-	private void compress(final int[] edgesArray) {
-		try {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			diffComp(edgesArray, new OutputBitStream(baos));
-			intervalsAndResiduals = baos.toByteArray();
-			size = edgesArray.length;
-		} catch (IOException e) {
-			throw new IllegalArgumentException(e);
-		}
-	}
+  /**
+   * Receives an integer array of successors and compresses them in the
+   * intervalsAndResiduals byte array
+   *
+   * @param edgesArray an integer array of successors
+   */
+  private void compress(final int[] edgesArray) {
+    try {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      diffComp(edgesArray, new OutputBitStream(baos));
+      intervalsAndResiduals = baos.toByteArray();
+      size = edgesArray.length;
+    } catch (IOException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
 
-	/**
-	 * See also {@link it.unimi.dsi.webgraph.BVGraph#diffComp(int[], OutputBitStream)}.
-	 * This method is given an integer successors array and produces, onto a given output
-	 * bit stream, the differentially compressed successor list.
-	 *
-	 * @param edgesArray the integer successors array
-	 * @param obs        an output bit stream where the compressed data will be
-	 *                   stored.
-	 */
-	public static void diffComp(final int[] edgesArray, OutputBitStream obs) throws IOException {
-		// We write the degree.
-		obs.writeInt(edgesArray.length, Integer.SIZE);
-		IntArrayList left = new IntArrayList();
-		IntArrayList len = new IntArrayList();
-		IntArrayList residuals = new IntArrayList();
-		// If we are to produce intervals, we first compute them.
-		int intervalCount;
-		try {
-			intervalCount = BVEdges.intervalize(edgesArray, BVGraph.DEFAULT_MIN_INTERVAL_LENGTH, Integer.MAX_VALUE,
-					left, len, residuals);
-		} catch (IllegalArgumentException e) {
-			// array was not sorted, sorting and retrying
-			Arrays.sort(edgesArray);
-			left = new IntArrayList();
-			len = new IntArrayList();
-			residuals = new IntArrayList();
-			intervalCount = BVEdges.intervalize(edgesArray, BVGraph.DEFAULT_MIN_INTERVAL_LENGTH, Integer.MAX_VALUE,
-					left, len, residuals);
-		}
-		// We write the number of intervals.
-		obs.writeGamma(intervalCount);
-		int currIntLen;
-		int prev = 0;
-		if (intervalCount > 0) {
-			obs.writeInt(left.getInt(0), Integer.SIZE);
-			currIntLen = len.getInt(0);
-			prev = left.getInt(0) + currIntLen;
-			obs.writeGamma(currIntLen - BVGraph.DEFAULT_MIN_INTERVAL_LENGTH);
-		}
-		// We write out the intervals.
-		for (int i = 1; i < intervalCount; i++) {
-			obs.writeGamma(left.getInt(i) - prev - 1);
-			currIntLen = len.getInt(i);
-			prev = left.getInt(i) + currIntLen;
-			obs.writeGamma(currIntLen - BVGraph.DEFAULT_MIN_INTERVAL_LENGTH);
-		}
-		final int[] residual = residuals.elements();
-		final int residualCount = residuals.size();
-		// Now we write out the residuals, if any
-		if (residualCount != 0) {
-			if (intervalCount > 0) {
-				obs.writeLongZeta(Fast.int2nat((long) (prev = residual[0]) - left.getInt(0)), BVGraph.DEFAULT_ZETA_K);
-			} else {
-				prev = residual[0];
-				obs.writeInt(prev, Integer.SIZE);
-			}
-			for (int i = 1; i < residualCount; i++) {
-				if (residual[i] == prev) {
-					throw new IllegalArgumentException(
-							"Repeated successor " + prev + " in successor list of this node");
-				}
-				obs.writeLongZeta(residual[i] - prev - 1L, BVGraph.DEFAULT_ZETA_K);
-				prev = residual[i];
-			}
-		}
-		obs.flush();
-	}
+  /**
+   * See also
+   * {@link it.unimi.dsi.webgraph.BVGraph#diffComp(int[], OutputBitStream)}.
+   * This method is given an integer successors array and produces, onto a given
+   * output bit stream, the differentially compressed successor list.
+   *
+   * @param edgesArray the integer successors array
+   * @param obs        an output bit stream where the compressed data will be
+   *                   stored.
+   */
+  public static void diffComp(final int[] edgesArray, OutputBitStream obs)
+      throws IOException {
+    // We write the degree.
+    obs.writeInt(edgesArray.length, Integer.SIZE);
+    IntArrayList left = new IntArrayList();
+    IntArrayList len = new IntArrayList();
+    IntArrayList residuals = new IntArrayList();
+    // If we are to produce intervals, we first compute them.
+    int intervalCount;
+    try {
+      intervalCount = BVEdges.intervalize(edgesArray,
+          BVGraph.DEFAULT_MIN_INTERVAL_LENGTH, Integer.MAX_VALUE, left, len,
+          residuals);
+    } catch (IllegalArgumentException e) {
+      // array was not sorted, sorting and retrying
+      Arrays.sort(edgesArray);
+      left = new IntArrayList();
+      len = new IntArrayList();
+      residuals = new IntArrayList();
+      intervalCount = BVEdges.intervalize(edgesArray,
+          BVGraph.DEFAULT_MIN_INTERVAL_LENGTH, Integer.MAX_VALUE, left, len,
+          residuals);
+    }
+    // We write the number of intervals.
+    obs.writeGamma(intervalCount);
+    int currIntLen;
+    int prev = 0;
+    if (intervalCount > 0) {
+      obs.writeInt(left.getInt(0), Integer.SIZE);
+      currIntLen = len.getInt(0);
+      prev = left.getInt(0) + currIntLen;
+      obs.writeGamma(currIntLen - BVGraph.DEFAULT_MIN_INTERVAL_LENGTH);
+    }
+    // We write out the intervals.
+    for (int i = 1; i < intervalCount; i++) {
+      obs.writeGamma(left.getInt(i) - prev - 1);
+      currIntLen = len.getInt(i);
+      prev = left.getInt(i) + currIntLen;
+      obs.writeGamma(currIntLen - BVGraph.DEFAULT_MIN_INTERVAL_LENGTH);
+    }
+    final int[] residual = residuals.elements();
+    final int residualCount = residuals.size();
+    // Now we write out the residuals, if any
+    if (residualCount != 0) {
+      if (intervalCount > 0) {
+        prev = residual[0];
+        obs.writeLongZeta(
+            Fast.int2nat((long) prev - left.getInt(0)),
+            BVGraph.DEFAULT_ZETA_K);
+      } else {
+        prev = residual[0];
+        obs.writeInt(prev, Integer.SIZE);
+      }
+      for (int i = 1; i < residualCount; i++) {
+        if (residual[i] == prev) {
+          throw new IllegalArgumentException(
+              "Repeated successor " + prev + " in successor list of this node");
+        }
+        obs.writeLongZeta(residual[i] - prev - 1L, BVGraph.DEFAULT_ZETA_K);
+        prev = residual[i];
+      }
+    }
+    obs.flush();
+  }
 
-	/**
-	 * See also
-	 * {@link it.unimi.dsi.webgraph.BVGraph#intervalize(IntArrayList, int, IntArrayList, IntArrayList, IntArrayList)}.
-	 * This method tries to express an increasing sequence of natural numbers
-	 * <code>x</code> as a union of an increasing sequence of intervals and an
-	 * increasing sequence of residual elements. More precisely, this
-	 * intervalization works as follows: first, one looks at <code>edgesArray</code>
-	 * as a sequence of intervals (i.e., maximal sequences of consecutive elements);
-	 * those intervals whose length is &ge; <code>minInterval</code> are stored in
-	 * the lists <code>left</code> (the list of left extremes) and <code>len</code>
-	 * (the list of lengths; the length of an integer interval is the number of
-	 * integers in that interval). The remaining integers, called <em>residuals</em>
-	 * are stored in the <code>residual</code> list.
-	 * 
-	 * <P>
-	 * Note that the previous content of <code>left</code>, <code>len</code> and
-	 * <code>residual</code> is lost.
-	 * 
-	 * @param edgesArray  the array to be intervalized (an increasing list of
-	 *                    natural numbers).
-	 * @param minInterval the least length that a maximal sequence of consecutive
-	 *                    elements must have in order for it to be considered as an
-	 *                    interval.
-	 * @param left        the resulting list of left extremes of the intervals.
-	 * @param len         the resulting list of interval lengths.
-	 * @param residuals   the resulting list of residuals.
-	 * @return the number of intervals.
-	 */
-	protected static int intervalize(final int[] edgesArray, final int minInterval,
-			final int maxInterval, final IntArrayList left, final IntArrayList len, final IntArrayList residuals) {
-		int nInterval = 0;
-		int i;
-		int j;
+  /**
+   * See also {@link it.unimi.dsi.webgraph.BVGraph#intervalize(IntArrayList,
+   * int, IntArrayList, IntArrayList, IntArrayList)}.
+   * This method tries to express an increasing sequence of natural numbers
+   * <code>x</code> as a union of an increasing sequence of intervals and an
+   * increasing sequence of residual elements. More precisely, this
+   * intervalization works as follows: first, one looks at
+   * <code>edgesArray</code> as a sequence of intervals (i.e., maximal sequences
+   * of consecutive elements); those intervals whose length is &ge;
+   * <code>minInterval</code> are stored in the lists <code>left</code> (the
+   * list of left extremes) and <code>len</code> (the list of lengths; the
+   * length of an integer interval is the number of integers in that interval).
+   * The remaining integers, called <em>residuals</em> are stored in the
+   * <code>residual</code> list.
+   *
+   * <P>
+   * Note that the previous content of <code>left</code>, <code>len</code> and
+   * <code>residual</code> is lost.
+   *
+   * @param edgesArray  the array to be intervalized (an increasing list of
+   *                    natural numbers).
+   * @param minInterval the least length that a maximal sequence of consecutive
+   *                    elements must have in order for it to be considered as
+   *                    an interval.
+   * @param maxInterval the maximum length that a maximal sequence of
+   *                    consecutive elements must have in order for it to be
+   *                    considered as an interval.
+   * @param left        the resulting list of left extremes of the intervals.
+   * @param len         the resulting list of interval lengths.
+   * @param residuals   the resulting list of residuals.
+   * @return the number of intervals.
+   */
+  protected static int intervalize(final int[] edgesArray,
+      final int minInterval, final int maxInterval, final IntArrayList left,
+      final IntArrayList len, final IntArrayList residuals) {
+    int nInterval = 0;
+    int i;
+    int j;
 
-		for (i = 0; i < edgesArray.length; i++) {
-			j = 0;
-			checkIsSorted(edgesArray, i);
-			if (i < edgesArray.length - 1 && edgesArray[i] + 1 == edgesArray[i + 1]) {
-				do
-					j++;
-				while (i + j < edgesArray.length - 1 && j < maxInterval
-						&& edgesArray[i + j] + 1 == edgesArray[i + j + 1]);
-				checkIsSorted(edgesArray, i + j);
-				j++;
-				// Now j is the number of integers in the interval.
-				if (j >= minInterval) {
-					left.add(edgesArray[i]);
-					len.add(j);
-					nInterval++;
-					i += j - 1;
-				}
-			}
-			if (j < minInterval)
-				residuals.add(edgesArray[i]);
-		}
-		return nInterval;
-	}
+    for (i = 0; i < edgesArray.length; i++) {
+      j = 0;
+      checkIsSorted(edgesArray, i);
+      if (i < edgesArray.length - 1 && edgesArray[i] + 1 == edgesArray[i + 1]) {
+        do {
+          j++;
+        } while (i + j < edgesArray.length - 1 && j < maxInterval &&
+            edgesArray[i + j] + 1 == edgesArray[i + j + 1]);
+        checkIsSorted(edgesArray, i + j);
+        j++;
+        // Now j is the number of integers in the interval.
+        if (j >= minInterval) {
+          left.add(edgesArray[i]);
+          len.add(j);
+          nInterval++;
+          i += j - 1;
+        }
+      }
+      if (j < minInterval) {
+        residuals.add(edgesArray[i]);
+      }
+    }
+    return nInterval;
+  }
 
-	/**
-	 * Given an integer array and an index, this method throws an exception in case
-	 * the element of the array the index points at is equal or larger than its
-	 * next.
-	 * 
-	 * @param edgesArray the integer array
-	 * @param i          the index
-	 */
-	private static void checkIsSorted(int[] edgesArray, int i) {
-		if (i < edgesArray.length - 1 && edgesArray[i] == edgesArray[i + 1]) {
-			throw new IllegalArgumentException("Parallel edges are not allowed.");
-		}
-		if (i < edgesArray.length - 1 && edgesArray[i] > edgesArray[i + 1]) {
-			throw new IllegalArgumentException("Edges are not sorted.");
-		}
-	}
+  /**
+   * Given an integer array and an index, this method throws an exception in
+   * case the element of the array the index points at is equal or larger than
+   * its next.
+   *
+   * @param edgesArray the integer array
+   * @param i          the index
+   */
+  private static void checkIsSorted(int[] edgesArray, int i) {
+    if (i < edgesArray.length - 1 && edgesArray[i] == edgesArray[i + 1]) {
+      throw new IllegalArgumentException("Parallel edges are not allowed.");
+    }
+    if (i < edgesArray.length - 1 && edgesArray[i] > edgesArray[i + 1]) {
+      throw new IllegalArgumentException("Edges are not sorted.");
+    }
+  }
 
-	/**
-	 * Iterator that reuses the same Edge object.
-	 */
-	private class BVEdgesIterator extends UnmodifiableIterator<Edge<IntWritable, NullWritable>> {
-		/** Wrapped map iterator. */
-		LazyIntIterator liIter = successors(new InputBitStream(intervalsAndResiduals));
-		/** Representative edge object. */
-		private final Edge<IntWritable, NullWritable> representativeEdge = EdgeFactory.create(new IntWritable());
-		/** Current edge count */
-		private int currentEdge = 0;
+  /**
+   * Iterator that reuses the same Edge object.
+   */
+  private class BVEdgesIterator
+      extends UnmodifiableIterator<Edge<IntWritable, NullWritable>> {
+    /** Wrapped map iterator. */
+    private LazyIntIterator liIter = successors(
+        new InputBitStream(intervalsAndResiduals));
+    /** Representative edge object. */
+    private final Edge<IntWritable, NullWritable> representativeEdge =
+        EdgeFactory.create(new IntWritable());
+    /** Current edge count */
+    private int currentEdge = 0;
 
-		@Override
-		public boolean hasNext() {
-			return currentEdge < size;
-		}
+    @Override
+    public boolean hasNext() {
+      return currentEdge < size;
+    }
 
-		@Override
-		public Edge<IntWritable, NullWritable> next() {
-			representativeEdge.getTargetVertexId().set(liIter.nextInt());
-			currentEdge++;
-			return representativeEdge;
-		}
+    @Override
+    public Edge<IntWritable, NullWritable> next() {
+      representativeEdge.getTargetVertexId().set(liIter.nextInt());
+      currentEdge++;
+      return representativeEdge;
+    }
 
-		private LazyIntIterator successors(InputBitStream ibs) {
-			try {
-				final int d;
-				int extraCount;
-				int firstIntervalNode = -1;
-				ibs.position(0);
-				d = ibs.readInt(Integer.SIZE);
-				if (d == 0)
-					return LazyIntIterators.EMPTY_ITERATOR;
-				extraCount = d;
-				int intervalCount = 0; // Number of intervals
-				int[] left = null;
-				int[] len = null;
-				// Prepare to read intervals, if any
-				if (extraCount > 0 && (intervalCount = ibs.readGamma()) != 0) {
-					int prev = 0; // Holds the last integer in the last
-									// interval.
-					left = new int[intervalCount];
-					len = new int[intervalCount];
-					// Now we read intervals
-					left[0] = firstIntervalNode = prev = ibs.readInt(Integer.SIZE);
-					len[0] = ibs.readGamma() + BVGraph.DEFAULT_MIN_INTERVAL_LENGTH;
+    /** Creates an iterator from an input bit stream
+     *
+     * @param ibs input bit stream with compressed intervals and residuals
+     * @return an iterator with the successors of the input bit stream
+     *
+     * */
+    private LazyIntIterator successors(InputBitStream ibs) {
+      try {
+        final int d;
+        int extraCount;
+        int firstIntervalNode = -1;
+        ibs.position(0);
+        d = ibs.readInt(Integer.SIZE);
+        if (d == 0) {
+          return LazyIntIterators.EMPTY_ITERATOR;
+        }
+        extraCount = d;
+        int intervalCount = 0; // Number of intervals
+        int[] left = null;
+        int[] len = null;
+        // Prepare to read intervals, if any
+        intervalCount = ibs.readGamma();
+        if (extraCount > 0 && intervalCount != 0) {
+          int prev = 0; // Holds the last integer in the last
+                        // interval.
+          left = new int[intervalCount];
+          len = new int[intervalCount];
+          // Now we read intervals
+          firstIntervalNode = ibs.readInt(Integer.SIZE);
+          left[0] = firstIntervalNode;
+          len[0] = ibs.readGamma() + BVGraph.DEFAULT_MIN_INTERVAL_LENGTH;
 
-					prev += len[0];
-					extraCount -= len[0];
-					for (int i = 1; i < intervalCount; i++) {
-						left[i] = prev = ibs.readGamma() + prev + 1;
-						len[i] = ibs.readGamma() + BVGraph.DEFAULT_MIN_INTERVAL_LENGTH;
-						prev += len[i];
-						extraCount -= len[i];
-					}
-				}
+          prev = left[0] + len[0];
+          extraCount -= len[0];
+          for (int i = 1; i < intervalCount; i++) {
+            left[i] = ibs.readGamma() + prev + 1;
+            len[i] = ibs.readGamma() + BVGraph.DEFAULT_MIN_INTERVAL_LENGTH;
+            prev = left[i] + len[i];
+            extraCount -= len[i];
+          }
+        }
 
-				final int residualCount = extraCount; // Just to be able to use
-														// an
-														// anonymous class.
-				final LazyIntIterator residualIterator = residualCount == 0 ? null
-						: new ResidualIntIterator(ibs, residualCount, firstIntervalNode);
-				// The extra part is made by the contribution of intervals, if
-				// any, and by the residuals iterator.
-				if (intervalCount == 0) {
-					return residualIterator;
-				} else if (residualCount == 0){
-					return new IntIntervalSequenceIterator(left, len);
-				} else {
-					return new MergedIntIterator(new IntIntervalSequenceIterator(left, len), residualIterator);
-				}
-			} catch (IOException e) {
-				throw new IllegalStateException(e);
-			}
-		}
+        final int residualCount = extraCount; // Just to be able to use
+                                              // an
+                                              // anonymous class.
+        final LazyIntIterator residualIterator = residualCount == 0 ? null :
+          new ResidualIntIterator(ibs, residualCount, firstIntervalNode);
+        // The extra part is made by the contribution of intervals, if
+        // any, and by the residuals iterator.
+        if (intervalCount == 0) {
+          return residualIterator;
+        } else if (residualCount == 0) {
+          return new IntIntervalSequenceIterator(left, len);
+        } else {
+          return new MergedIntIterator(
+              new IntIntervalSequenceIterator(left, len), residualIterator);
+        }
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
 
-		/** An iterator returning the residuals of a node. */
-		private final class ResidualIntIterator extends AbstractLazyIntIterator {
-			/** The input bit stream from which residuals will be read. */
-			private final InputBitStream ibs;
-			/** The last residual returned. */
-			private int next;
-			/** The number of remaining residuals. */
-			private int remaining;
+    /** An iterator returning the residuals of a node. */
+    private final class ResidualIntIterator extends AbstractLazyIntIterator {
+      /** The input bit stream from which residuals will be read. */
+      private final InputBitStream ibs;
+      /** The last residual returned. */
+      private int next;
+      /** The number of remaining residuals. */
+      private int remaining;
 
-			private ResidualIntIterator(final InputBitStream ibs, final int residualCount, int x) {
-				this.remaining = residualCount;
-				this.ibs = ibs;
-				try {
-					if (x >= 0) {
-						long temp = Fast.nat2int(ibs.readLongZeta(BVGraph.DEFAULT_ZETA_K));
-						this.next = (int) (x + temp);
-					} else {
-						this.next = ibs.readInt(Integer.SIZE);
-					}
-				} catch (IOException e) {
-					throw new IllegalStateException(e);
-				}
-			}
+      /** Constructor
+       *
+       * @param ibs the input bit stream with the residuals
+       * @param remaining the total elements in the stream
+       * @param x the value of the previous (or first) edge id
+       *
+       * */
+      private ResidualIntIterator(final InputBitStream ibs,
+          final int remaining, int x) {
+        this.remaining = remaining;
+        this.ibs = ibs;
+        try {
+          if (x >= 0) {
+            long temp = Fast.nat2int(ibs.readLongZeta(BVGraph.DEFAULT_ZETA_K));
+            this.next = (int) (x + temp);
+          } else {
+            this.next = ibs.readInt(Integer.SIZE);
+          }
+        } catch (IOException e) {
+          throw new IllegalStateException(e);
+        }
+      }
 
-			public int nextInt() {
-				if (remaining == 0)
-					return -1;
-				try {
-					final int result = next;
-					if (--remaining != 0)
-						next += ibs.readZeta(BVGraph.DEFAULT_ZETA_K) + 1;
-					return result;
-				} catch (IOException cantHappen) {
-					throw new IllegalStateException(cantHappen);
-				}
-			}
+      /** Return the next integer of the iterator
+       *
+       * @return the next integer of the iterator
+       * */
+      public int nextInt() {
+        if (remaining == 0) {
+          return -1;
+        }
+        try {
+          final int result = next;
+          if (--remaining != 0) {
+            next += ibs.readZeta(BVGraph.DEFAULT_ZETA_K) + 1;
+          }
+          return result;
+        } catch (IOException cantHappen) {
+          throw new IllegalStateException(cantHappen);
+        }
+      }
 
-			@Override
-			public int skip(int n) {
-				if (n >= remaining) {
-					n = remaining;
-					remaining = 0;
-					return n;
-				}
-				try {
-					for (int i = n; i-- != 0;)
-						next += ibs.readZeta(BVGraph.DEFAULT_ZETA_K) + 1;
-					remaining -= n;
-					return n;
-				} catch (IOException cantHappen) {
-					throw new IllegalStateException(cantHappen);
-				}
-			}
+      @Override
+      public int skip(int n) {
+        if (n >= remaining) {
+          n = remaining;
+          remaining = 0;
+          return n;
+        }
+        try {
+          for (int i = n; i-- != 0;) {
+            next += ibs.readZeta(BVGraph.DEFAULT_ZETA_K) + 1;
+          }
+          remaining -= n;
+          return n;
+        } catch (IOException cantHappen) {
+          throw new IllegalStateException(cantHappen);
+        }
+      }
 
-		}
+    }
 
-	}
+  }
 
 }

--- a/giraph-core/src/main/java/org/apache/giraph/edge/BVEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/BVEdges.java
@@ -1,0 +1,409 @@
+package org.apache.giraph.edge;
+
+import it.unimi.dsi.bits.Fast;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.io.InputBitStream;
+import it.unimi.dsi.io.OutputBitStream;
+import it.unimi.dsi.webgraph.AbstractLazyIntIterator;
+import it.unimi.dsi.webgraph.BVGraph;
+import it.unimi.dsi.webgraph.IntIntervalSequenceIterator;
+import it.unimi.dsi.webgraph.LazyIntIterator;
+import it.unimi.dsi.webgraph.LazyIntIterators;
+import it.unimi.dsi.webgraph.MergedIntIterator;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.stream.StreamSupport;
+
+import org.apache.giraph.utils.Trimmable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.weakref.jmx.com.google.common.collect.Iterators;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.UnmodifiableIterator;
+
+public class BVEdges extends ConfigurableOutEdges<IntWritable, NullWritable>
+		implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {
+
+	/** Serialized Intervals and Residuals */
+	private byte[] intervalsAndResiduals;
+	/** Number of edges. */
+	private int size;
+
+	@Override
+	public void initialize(Iterable<Edge<IntWritable, NullWritable>> edges) {
+		compress(StreamSupport.stream(edges.spliterator(), false).map(Edge::getTargetVertexId)
+				.mapToInt(IntWritable::get).toArray());
+	}
+
+	@Override
+	public void initialize(int capacity) {
+		size = 0;
+		intervalsAndResiduals = null;
+	}
+
+	@Override
+	public void initialize() {
+		size = 0;
+		intervalsAndResiduals = null;
+	}
+
+	@Override
+	public void add(Edge<IntWritable, NullWritable> edge) {
+		// Note that ths is very expensive (decompresses all edges and recompresses them again).
+		compress(StreamSupport
+				.stream(((Iterable<Edge<IntWritable, NullWritable>>) () -> Iterators.concat(this.iterator(),
+						ImmutableSet.of(edge).iterator())).spliterator(), false)
+				.map(Edge::getTargetVertexId).mapToInt(IntWritable::get).sorted().toArray());
+	}
+
+	@Override
+	public void remove(IntWritable targetVertexId) {
+		// Note that this is very expensive (decompresses all edges and recompresses them again).
+		initialize(Iterables.filter(this,
+				edge -> !((Edge<IntWritable, NullWritable>) edge).getTargetVertexId().equals(targetVertexId)));
+	}
+
+	@Override
+	public int size() {
+		return size;
+	}
+	
+	@Override
+	public Iterator<Edge<IntWritable, NullWritable>> iterator() {
+		if (size == 0) {
+			return ImmutableSet.<Edge<IntWritable, NullWritable>>of().iterator();
+		} else {
+			return new BVEdgesIterator();
+		}
+	}
+
+	@Override
+	public void readFields(DataInput in) throws IOException {
+		size = in.readInt();
+		int intervalResidualEdgesBytesUsed = in.readInt();
+		if (intervalResidualEdgesBytesUsed > 0) {
+			// Only create a new buffer if the old one isn't big enough
+			if (intervalsAndResiduals == null || intervalResidualEdgesBytesUsed > intervalsAndResiduals.length) {
+				intervalsAndResiduals = new byte[intervalResidualEdgesBytesUsed];
+			}
+			in.readFully(intervalsAndResiduals, 0, intervalResidualEdgesBytesUsed);
+		}
+	}
+
+	@Override
+	public void write(DataOutput out) throws IOException {
+		out.writeInt(size);
+		out.writeInt(intervalsAndResiduals.length);
+		if (intervalsAndResiduals.length > 0) {
+			out.write(intervalsAndResiduals, 0, intervalsAndResiduals.length);
+		}
+	}
+
+	@Override
+	public void trim() {
+		// Nothing to do
+	}
+
+
+	/**
+	 * Receives an integer array of successors and compresses them in the
+	 * intervalsAndResiduals byte array
+	 * 
+	 * @param edgesArray an integer array of successors
+	 */
+	private void compress(final int[] edgesArray) {
+		try {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			diffComp(edgesArray, new OutputBitStream(baos));
+			intervalsAndResiduals = baos.toByteArray();
+			size = edgesArray.length;
+		} catch (IOException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	/**
+	 * See also {@link it.unimi.dsi.webgraph.BVGraph#diffComp(int[], OutputBitStream)}.
+	 * This method is given an integer successors array and produces, onto a given output
+	 * bit stream, the differentially compressed successor list.
+	 *
+	 * @param edgesArray the integer successors array
+	 * @param obs        an output bit stream where the compressed data will be
+	 *                   stored.
+	 */
+	public static <E extends Writable> void diffComp(final int[] edgesArray, OutputBitStream obs) throws IOException {
+		// We write the degree.
+		obs.writeInt(edgesArray.length, Integer.SIZE);
+		final int residual[], residualCount;
+		IntArrayList left = new IntArrayList();
+		IntArrayList len = new IntArrayList();
+		IntArrayList residuals = new IntArrayList();
+		// If we are to produce intervals, we first compute them.
+		int intervalCount;
+		try {
+			intervalCount = BVEdges.intervalize(edgesArray, BVGraph.DEFAULT_MIN_INTERVAL_LENGTH, Integer.MAX_VALUE,
+					left, len, residuals);
+		} catch (IllegalArgumentException e) {
+			// array was not sorted, sorting and retrying
+			Arrays.sort(edgesArray);
+			left = new IntArrayList();
+			len = new IntArrayList();
+			residuals = new IntArrayList();
+			intervalCount = BVEdges.intervalize(edgesArray, BVGraph.DEFAULT_MIN_INTERVAL_LENGTH, Integer.MAX_VALUE,
+					left, len, residuals);
+		}
+		// We write the number of intervals.
+		obs.writeGamma(intervalCount);
+		int currIntLen;
+		int prev = 0;
+		if (intervalCount > 0) {
+			obs.writeInt(left.getInt(0), Integer.SIZE);
+			currIntLen = len.getInt(0);
+			prev = left.getInt(0) + currIntLen;
+			obs.writeGamma(currIntLen - BVGraph.DEFAULT_MIN_INTERVAL_LENGTH);
+		}
+		// We write out the intervals.
+		for (int i = 1; i < intervalCount; i++) {
+			obs.writeGamma(left.getInt(i) - prev - 1);
+			currIntLen = len.getInt(i);
+			prev = left.getInt(i) + currIntLen;
+			obs.writeGamma(currIntLen - BVGraph.DEFAULT_MIN_INTERVAL_LENGTH);
+		}
+		residual = residuals.elements();
+		residualCount = residuals.size();
+		// Now we write out the residuals, if any
+		if (residualCount != 0) {
+			if (intervalCount > 0) {
+				obs.writeLongZeta(Fast.int2nat((long) (prev = residual[0]) - left.getInt(0)), BVGraph.DEFAULT_ZETA_K);
+			} else {
+				obs.writeInt((prev = residual[0]), Integer.SIZE);
+			}
+			for (int i = 1; i < residualCount; i++) {
+				if (residual[i] == prev) {
+					throw new IllegalArgumentException(
+							"Repeated successor " + prev + " in successor list of this node");
+				}
+				obs.writeLongZeta(residual[i] - prev - 1, BVGraph.DEFAULT_ZETA_K);
+				prev = residual[i];
+			}
+		}
+		obs.flush();
+	}
+
+	/**
+	 * See also
+	 * {@link it.unimi.dsi.webgraph.BVGraph#intervalize(IntArrayList, int, IntArrayList, IntArrayList, IntArrayList)}.
+	 * This method tries to express an increasing sequence of natural numbers
+	 * <code>x</code> as a union of an increasing sequence of intervals and an
+	 * increasing sequence of residual elements. More precisely, this
+	 * intervalization works as follows: first, one looks at <code>edgesArray</code>
+	 * as a sequence of intervals (i.e., maximal sequences of consecutive elements);
+	 * those intervals whose length is &ge; <code>minInterval</code> are stored in
+	 * the lists <code>left</code> (the list of left extremes) and <code>len</code>
+	 * (the list of lengths; the length of an integer interval is the number of
+	 * integers in that interval). The remaining integers, called <em>residuals</em>
+	 * are stored in the <code>residual</code> list.
+	 * 
+	 * <P>
+	 * Note that the previous content of <code>left</code>, <code>len</code> and
+	 * <code>residual</code> is lost.
+	 * 
+	 * @param edgesArray  the array to be intervalized (an increasing list of
+	 *                    natural numbers).
+	 * @param minInterval the least length that a maximal sequence of consecutive
+	 *                    elements must have in order for it to be considered as an
+	 *                    interval.
+	 * @param left        the resulting list of left extremes of the intervals.
+	 * @param len         the resulting list of interval lengths.
+	 * @param residuals   the resulting list of residuals.
+	 * @return the number of intervals.
+	 */
+	protected static <E extends Writable> int intervalize(final int[] edgesArray, final int minInterval,
+			final int maxInterval, final IntArrayList left, final IntArrayList len, final IntArrayList residuals) {
+		int nInterval = 0;
+		int i, j;
+
+		for (i = 0; i < edgesArray.length; i++) {
+			j = 0;
+			checkIsSorted(edgesArray, i);
+			if (i < edgesArray.length - 1 && edgesArray[i] + 1 == edgesArray[i + 1]) {
+				do
+					j++;
+				while (i + j < edgesArray.length - 1 && j < maxInterval
+						&& edgesArray[i + j] + 1 == edgesArray[i + j + 1]);
+				checkIsSorted(edgesArray, i + j);
+				j++;
+				// Now j is the number of integers in the interval.
+				if (j >= minInterval) {
+					left.add(edgesArray[i]);
+					len.add(j);
+					nInterval++;
+					i += j - 1;
+				}
+			}
+			if (j < minInterval)
+				residuals.add(edgesArray[i]);
+		}
+		return nInterval;
+	}
+
+	/**
+	 * Given an integer array and an index, this method throws an exception in case
+	 * the element of the array the index points at is equal or larger than its
+	 * next.
+	 * 
+	 * @param edgesArray the integer array
+	 * @param i          the index
+	 */
+	private static void checkIsSorted(int[] edgesArray, int i) {
+		if (i < edgesArray.length - 1 && edgesArray[i] == edgesArray[i + 1]) {
+			throw new IllegalArgumentException("Parallel edges are not allowed.");
+		}
+		if (i < edgesArray.length - 1 && edgesArray[i] > edgesArray[i + 1]) {
+			throw new IllegalArgumentException("Edges are not sorted.");
+		}
+	}
+
+	/**
+	 * Iterator that reuses the same Edge object.
+	 */
+	private class BVEdgesIterator extends UnmodifiableIterator<Edge<IntWritable, NullWritable>> {
+		/** Wrapped map iterator. */
+		LazyIntIterator liIter = successors(new InputBitStream(intervalsAndResiduals));
+		/** Representative edge object. */
+		private final Edge<IntWritable, NullWritable> representativeEdge = EdgeFactory.create(new IntWritable());
+		/** Current edge count */
+		private int currentEdge = 0;
+
+		@Override
+		public boolean hasNext() {
+			return currentEdge < size;
+		}
+
+		@Override
+		public Edge<IntWritable, NullWritable> next() {
+			representativeEdge.getTargetVertexId().set(liIter.nextInt());
+			currentEdge++;
+			return representativeEdge;
+		}
+
+		private LazyIntIterator successors(InputBitStream ibs) {
+			try {
+				final int d;
+				int extraCount;
+				int firstIntervalNode = -1;
+				ibs.position(0);
+				d = ibs.readInt(Integer.SIZE);
+				if (d == 0)
+					return LazyIntIterators.EMPTY_ITERATOR;
+				extraCount = d;
+				int intervalCount = 0; // Number of intervals
+				int[] left = null;
+				int[] len = null;
+				if (extraCount > 0) {
+					// Prepare to read intervals, if any
+					if ((intervalCount = ibs.readGamma()) != 0) {
+						int prev = 0; // Holds the last integer in the last
+										// interval.
+						left = new int[intervalCount];
+						len = new int[intervalCount];
+						// Now we read intervals
+						left[0] = firstIntervalNode = prev = ibs.readInt(Integer.SIZE);
+						len[0] = ibs.readGamma() + BVGraph.DEFAULT_MIN_INTERVAL_LENGTH;
+
+						prev += len[0];
+						extraCount -= len[0];
+						for (int i = 1; i < intervalCount; i++) {
+							left[i] = prev = ibs.readGamma() + prev + 1;
+							len[i] = ibs.readGamma() + BVGraph.DEFAULT_MIN_INTERVAL_LENGTH;
+							prev += len[i];
+							extraCount -= len[i];
+						}
+					}
+				}
+
+				final int residualCount = extraCount; // Just to be able to use
+														// an
+														// anonymous class.
+				final LazyIntIterator residualIterator = residualCount == 0 ? null
+						: new ResidualIntIterator(ibs, residualCount, firstIntervalNode);
+				// The extra part is made by the contribution of intervals, if
+				// any, and by the residuals iterator.
+				final LazyIntIterator extraIterator = intervalCount == 0 ? residualIterator
+						: (residualCount == 0 ? (LazyIntIterator) new IntIntervalSequenceIterator(left, len)
+								: (LazyIntIterator) new MergedIntIterator(new IntIntervalSequenceIterator(left, len),
+										residualIterator));
+				return extraIterator;
+			} catch (IOException e) {
+				e.printStackTrace();
+				return null;
+			}
+		}
+
+		/** An iterator returning the residuals of a node. */
+		private final class ResidualIntIterator extends AbstractLazyIntIterator {
+			/** The input bit stream from which residuals will be read. */
+			private final InputBitStream ibs;
+			/** The last residual returned. */
+			private int next;
+			/** The number of remaining residuals. */
+			private int remaining;
+
+			private ResidualIntIterator(final InputBitStream ibs, final int residualCount, int x) {
+				this.remaining = residualCount;
+				this.ibs = ibs;
+				try {
+					if (x >= 0) {
+						long temp = Fast.nat2int(ibs.readLongZeta(BVGraph.DEFAULT_ZETA_K));
+						this.next = (int) (x + temp);
+					} else {
+						this.next = ibs.readInt(Integer.SIZE);
+					}
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+
+			public int nextInt() {
+				if (remaining == 0)
+					return -1;
+				try {
+					final int result = next;
+					if (--remaining != 0)
+						next += ibs.readZeta(BVGraph.DEFAULT_ZETA_K) + 1;
+					return result;
+				} catch (IOException cantHappen) {
+					throw new RuntimeException(cantHappen);
+				}
+			}
+
+			@Override
+			public int skip(int n) {
+				if (n >= remaining) {
+					n = remaining;
+					remaining = 0;
+					return n;
+				}
+				try {
+					for (int i = n; i-- != 0;)
+						next += ibs.readZeta(BVGraph.DEFAULT_ZETA_K) + 1;
+					remaining -= n;
+					return n;
+				} catch (IOException cantHappen) {
+					throw new RuntimeException(cantHappen);
+				}
+			}
+
+		}
+
+	}
+
+}

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IndexedBitArrayEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IndexedBitArrayEdges.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.giraph.edge;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.UnmodifiableIterator;
+
+import org.apache.giraph.utils.Trimmable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.python.google.common.primitives.Bytes;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.stream.StreamSupport;
+
+/**
+ * Implementation of {@link OutEdges} with int ids and null edge values, backed
+ * by the IndexedBitArrayEdges structure proposed in "Panagiotis Liakos, Katia
+ * Papakonstantinopoulou, Alex Delis: Realizing Memory-Optimized Distributed
+ * Graph Processing. IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018)". Note:
+ * this implementation is optimized for space usage for graphs exhibiting the
+ * locality of reference property, but edge addition and
+ * removals are expensive. Parallel edges are not allowed.
+ */
+public class IndexedBitArrayEdges extends ConfigurableOutEdges<IntWritable, NullWritable>
+		implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {
+
+	/** Serialized edges. */
+	private byte[] serializedEdges;
+	/** Number of edges. */
+	private int size;
+
+	@Override
+	public void initialize(Iterable<Edge<IntWritable, NullWritable>> edges) {
+		initialize();
+		int[] sortedEdgesArray = StreamSupport.stream(edges.spliterator(), false).map(Edge::getTargetVertexId)
+				.mapToInt(IntWritable::get).sorted().distinct().toArray();
+		if (sortedEdgesArray.length == 0) {
+			return;
+		}
+		int currBucket = sortedEdgesArray[0] / Byte.SIZE;
+		byte myByte = (byte) 0;
+		for (int edge : sortedEdgesArray) {
+			int bucket = edge / Byte.SIZE;
+			int pos = edge % Byte.SIZE;
+			if (bucket == currBucket) {
+				myByte = setBit(myByte, pos);
+				size += 1;
+			} else {
+				serializedEdges = addBytes(serializedEdges, toByteArray(currBucket), myByte);
+				currBucket = bucket;
+				myByte = setBit((byte) 0, pos);
+				size += 1;
+			}
+		}
+		serializedEdges = addBytes(serializedEdges, toByteArray(currBucket), myByte);
+	}
+
+	@Override
+	public void initialize(int capacity) {
+		size = 0;
+		serializedEdges = new byte[0];
+	}
+
+	@Override
+	public void initialize() {
+		size = 0;
+		serializedEdges = new byte[0];
+	}
+
+	@Override
+	public void add(Edge<IntWritable, NullWritable> edge) {
+		int bucket = edge.getTargetVertexId().get() / Byte.SIZE;
+		int pos = edge.getTargetVertexId().get() % Byte.SIZE;
+		int i = 0;
+		boolean done = false;
+		while (i < serializedEdges.length) { // if bucket is already there, simply set the appropriate bit
+			if (fromByteArray(Arrays.copyOfRange(serializedEdges, i, i + Integer.SIZE / Byte.SIZE)) == bucket) {
+				int index = i + Integer.SIZE / Byte.SIZE;
+				if (!isSet(serializedEdges[index], pos)) {
+					size += 1;
+					serializedEdges[index] = setBit(serializedEdges[index], pos);
+				}
+				done = true;
+				break;
+			}
+			i += Integer.SIZE / Byte.SIZE + 1;
+		}
+		if (!done) { // we need to add a bucket
+			serializedEdges = addBytes(serializedEdges, toByteArray(bucket), setBit((byte) 0, pos));
+			size += 1;
+		}
+	}
+
+	@Override
+	public void remove(IntWritable targetVertexId) {
+		int bucket = targetVertexId.get() / Byte.SIZE;
+		int pos = targetVertexId.get() % Byte.SIZE;
+		int i = 0;
+		while (i < serializedEdges.length) {
+			if (fromByteArray(Arrays.copyOfRange(serializedEdges, i, i + Integer.SIZE / Byte.SIZE)) == bucket) {
+				serializedEdges[i + Integer.SIZE / Byte.SIZE] = unsetBit(serializedEdges[i + Integer.SIZE / Byte.SIZE],
+						pos);
+				--size;
+				break;
+			}
+			i += Integer.SIZE / Byte.SIZE + 1;
+		}
+	}
+
+	@Override
+	public int size() {
+		return size;
+	}
+
+	@Override
+	public void trim() {
+		// Nothing to do
+	}
+	
+	@Override
+	public Iterator<Edge<IntWritable, NullWritable>> iterator() {
+		if (size == 0) {
+			return ImmutableSet.<Edge<IntWritable, NullWritable>>of().iterator();
+		} else {
+			return new IndexedBitmapEdgeIterator();
+		}
+	}
+
+	@Override
+	public void readFields(DataInput in) throws IOException {
+		size = in.readInt();
+		int serializedEdgesBytesUsed = in.readInt();
+		if (serializedEdgesBytesUsed > 0) {
+			// Only create a new buffer if the old one isn't big enough
+			if (serializedEdges == null || serializedEdgesBytesUsed > serializedEdges.length) {
+				serializedEdges = new byte[serializedEdgesBytesUsed];
+			}
+			in.readFully(serializedEdges, 0, serializedEdgesBytesUsed);
+		}
+	}
+
+	@Override
+	public void write(DataOutput out) throws IOException {
+		out.writeInt(size);
+		out.writeInt(serializedEdges.length);
+		if (serializedEdges.length > 0) {
+			out.write(serializedEdges, 0, serializedEdges.length);
+		}
+	}
+
+	/** Iterator that reuses the same Edge object. */
+	private class IndexedBitmapEdgeIterator extends UnmodifiableIterator<Edge<IntWritable, NullWritable>> {
+		/** Representative edge object. */
+		private final Edge<IntWritable, NullWritable> representativeEdge = EdgeFactory.create(new IntWritable());
+		/** Current edge count */
+		private int currentEdge = 0;
+		/** Current position */
+		private int currentBitPosition = 0;
+		private int currentBytePosition = 0;
+		/** Index int */
+		private int indexInt;
+		/** Current byte */
+		private Byte myByte;
+		/** Current index */
+		private byte[] myBytes = new byte[Integer.SIZE / Byte.SIZE];
+
+		@Override
+		public boolean hasNext() {
+			return currentEdge < size;
+		}
+
+		@Override
+		public Edge<IntWritable, NullWritable> next() {
+			if (currentBitPosition == 8) {
+				currentBitPosition = 0;
+			}
+			if (currentBitPosition == 0) {
+				myBytes[0] = serializedEdges[currentBytePosition];
+				myBytes[1] = serializedEdges[currentBytePosition + 1];
+				myBytes[2] = serializedEdges[currentBytePosition + 2];
+				myBytes[3] = serializedEdges[currentBytePosition + 3];
+				indexInt = fromByteArray(myBytes);
+				myByte = serializedEdges[currentBytePosition + Integer.SIZE / Byte.SIZE];
+				currentBytePosition += Integer.SIZE / Byte.SIZE + 1;
+			}
+			int pos = currentBitPosition;
+			int nextPos = 0;
+			boolean done = false;
+			while (!done) {
+				for (int i = pos; i < Byte.SIZE; i++) {
+					if (isSet(myByte, i)) {
+						done = true;
+						nextPos = i;
+						currentEdge++;
+						currentBitPosition = i + 1;
+						break;
+					}
+				}
+				if (!done /* && mapIterator.hasNext() */) {
+					myBytes[0] = serializedEdges[currentBytePosition];
+					myBytes[1] = serializedEdges[currentBytePosition + 1];
+					myBytes[2] = serializedEdges[currentBytePosition + 2];
+					myBytes[3] = serializedEdges[currentBytePosition + 3];
+					indexInt = fromByteArray(myBytes);
+					myByte = serializedEdges[currentBytePosition + Integer.SIZE / Byte.SIZE];
+					currentBytePosition += Integer.SIZE / Byte.SIZE + 1;
+					pos = 0;
+				}
+			}
+			representativeEdge.getTargetVertexId().set(indexInt * Byte.SIZE + nextPos);
+			return representativeEdge;
+		}
+
+	}
+
+	/**
+	 * tests if bit is set in a byte
+	 * 
+	 * @param myByte the byte to be tested
+	 * @param pos    the position in the byte to be tested
+	 * @returns true or false depending on the bit being set
+	 * 
+	 */
+	public static boolean isSet(byte myByte, int pos) {
+		return (myByte & (1 << pos)) != 0;
+	}
+
+	/**
+	 * tests if bit is set in a byte
+	 * 
+	 * @param byteWritable the byte to be updated
+	 * @param pos          the position in the byte to be set
+	 * @returns the updated byte
+	 * 
+	 */
+	public static byte setBit(byte myByte, int pos) {
+		return (byte) (myByte | (1 << pos));
+	}
+
+	/**
+	 * tests if bit is set in a byte
+	 * 
+	 * @param my_byte the byte to be updated
+	 * @param pos     the position in the byte to be unset
+	 * @returns the updated byte
+	 * 
+	 */
+	public static byte unsetBit(byte myByte, int pos) {
+		return (byte) (myByte & ~(1 << pos));
+	}
+
+	/**
+	 * converts an integer to a 4-byte length array holding
+	 * its binary representation
+	 * 
+	 * @param value the integer to be converted
+	 * @return the 4-byte length byte array holding the integer's
+	 * binary representation
+	 */
+	public static byte[] toByteArray(int value) {
+		return new byte[] { (byte) (value >> 24), (byte) (value >> 16), (byte) (value >> 8), (byte) value };
+	}
+
+	/**
+	 * converts a 4-byte length byte array to its respective integer
+	 * 
+	 * @param bytes a 4-byte length byte array
+	 * @return the integer represented in the byte array
+	 */
+	public static int fromByteArray(byte[] bytes) {
+		return bytes[0] << 24 | (bytes[1] & 0xFF) << 16 | (bytes[2] & 0xFF) << 8 | (bytes[3] & 0xFF);
+	}
+
+	/**
+	 * returns a byte arrray with the concatenation of the three input parameters
+	 * 
+	 * @param original a byte array
+	 * @param bindex a byte array
+	 * @param myByte a byte
+	 * @return a byte arrray with the concatenation of the three input parameters
+	 * */
+	public static byte[] addBytes(byte[] original, byte[] bindex, byte myByte) {
+		byte[] destination = new byte[original.length + Integer.SIZE / Byte.SIZE + 1];
+		System.arraycopy(original, 0, destination, 0, original.length);
+		System.arraycopy(bindex, 0, destination, original.length, Integer.SIZE / Byte.SIZE);
+		destination[destination.length - 1] = myByte;
+		return destination;
+	}
+
+}

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IndexedBitArrayEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IndexedBitArrayEdges.java
@@ -292,12 +292,12 @@ public class IndexedBitArrayEdges extends ConfigurableOutEdges<IntWritable, Null
 	}
 
 	/**
-	 * returns a byte arrray with the concatenation of the three input parameters
+	 * returns a byte array with the concatenation of the three input parameters
 	 * 
 	 * @param original a byte array
 	 * @param bindex a byte array
 	 * @param myByte a byte
-	 * @return a byte arrray with the concatenation of the three input parameters
+	 * @return a byte array with the concatenation of the three input parameters
 	 * */
 	public static byte[] addBytes(byte[] original, byte[] bindex, byte myByte) {
 		byte[] destination = new byte[original.length + Integer.SIZE / Byte.SIZE + 1];

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IndexedBitArrayEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IndexedBitArrayEdges.java
@@ -21,6 +21,8 @@ package org.apache.giraph.edge;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.UnmodifiableIterator;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+
 import org.apache.giraph.utils.Trimmable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.NullWritable;
@@ -30,284 +32,313 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.stream.StreamSupport;
 
 /**
  * Implementation of {@link OutEdges} with int ids and null edge values, backed
  * by the IndexedBitArrayEdges structure proposed in:
- * 
+ *
  * Panagiotis Liakos, Katia Papakonstantinopoulou, Alex Delis:
  * Realizing Memory-Optimized Distributed Graph Processing.
  * IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018).
- * 
- * Note: this implementation is optimized for space usage for graphs exhibiting the
- * locality of reference property, but edge addition and
- * removals are expensive. Parallel edges are ignored.
+ *
+ * Note: this implementation is optimized for space usage for graphs exhibiting
+ * the locality of reference property, but edge addition and removals are
+ * expensive. Parallel edges are ignored.
  */
-public class IndexedBitArrayEdges extends ConfigurableOutEdges<IntWritable, NullWritable>
-		implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {
+public class IndexedBitArrayEdges
+    extends ConfigurableOutEdges<IntWritable, NullWritable>
+    implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {
 
-	/** Serialized edges. */
-	private byte[] serializedEdges;
-	/** Number of edges. */
-	private int size;
+  /** Serialized edges. */
+  private byte[] serializedEdges;
+  /** Number of edges. */
+  private int size;
 
-	@Override
-	public void initialize(Iterable<Edge<IntWritable, NullWritable>> edges) {
-		initialize();
-		int[] sortedEdgesArray = StreamSupport.stream(edges.spliterator(), false).map(Edge::getTargetVertexId)
-				.mapToInt(IntWritable::get).sorted().distinct().toArray();
-		if (sortedEdgesArray.length == 0) {
-			return;
-		}
-		int currBucket = sortedEdgesArray[0] / Byte.SIZE;
-		byte myByte = (byte) 0;
-		for (int edge : sortedEdgesArray) {
-			int bucket = edge / Byte.SIZE;
-			int pos = edge % Byte.SIZE;
-			if (bucket == currBucket) {
-				myByte = setBit(myByte, pos);
-				size += 1;
-			} else {
-				serializedEdges = addBytes(serializedEdges, toByteArray(currBucket), myByte);
-				currBucket = bucket;
-				myByte = setBit((byte) 0, pos);
-				size += 1;
-			}
-		}
-		serializedEdges = addBytes(serializedEdges, toByteArray(currBucket), myByte);
-	}
+  @Override
+  public void initialize(Iterable<Edge<IntWritable, NullWritable>> edges) {
+    initialize();
+    IntArrayList edgesList = new IntArrayList();
+    for (Iterator<Edge<IntWritable, NullWritable>> iter = edges.iterator(); iter
+        .hasNext();) {
+      edgesList.add(iter.next().getTargetVertexId().get());
+    }
+    int[] edgesArray = Arrays.copyOfRange(edgesList.elements(), 0,
+        edgesList.size());
+    Arrays.sort(edgesArray);
+    if (edgesArray.length == 0) {
+      return;
+    }
+    int previousId = -1;
+    int currBucket = edgesArray[0] / Byte.SIZE;
+    byte myByte = (byte) 0;
+    for (int edge : edgesArray) {
+      if (edge == previousId) {
+        throw new IllegalArgumentException("Repeated successor " + previousId +
+            " in successor list of this node");
+      }
+      previousId = edge;
+      int bucket = edge / Byte.SIZE;
+      int pos = edge % Byte.SIZE;
+      if (bucket == currBucket) {
+        myByte = setBit(myByte, pos);
+        size += 1;
+      } else {
+        serializedEdges = addBytes(serializedEdges, toByteArray(currBucket),
+            myByte);
+        currBucket = bucket;
+        myByte = setBit((byte) 0, pos);
+        size += 1;
+      }
+    }
+    serializedEdges = addBytes(serializedEdges, toByteArray(currBucket),
+        myByte);
+  }
 
-	@Override
-	public void initialize(int capacity) {
-		size = 0;
-		serializedEdges = new byte[0];
-	}
+  @Override
+  public void initialize(int capacity) {
+    size = 0;
+    serializedEdges = new byte[0];
+  }
 
-	@Override
-	public void initialize() {
-		size = 0;
-		serializedEdges = new byte[0];
-	}
+  @Override
+  public void initialize() {
+    size = 0;
+    serializedEdges = new byte[0];
+  }
 
-	@Override
-	public void add(Edge<IntWritable, NullWritable> edge) {
-		int bucket = edge.getTargetVertexId().get() / Byte.SIZE;
-		int pos = edge.getTargetVertexId().get() % Byte.SIZE;
-		int i = 0;
-		boolean done = false;
-		while (i < serializedEdges.length) { // if bucket is already there, simply set the appropriate bit
-			if (fromByteArray(Arrays.copyOfRange(serializedEdges, i, i + Integer.SIZE / Byte.SIZE)) == bucket) {
-				int index = i + Integer.SIZE / Byte.SIZE;
-				if (!isSet(serializedEdges[index], pos)) {
-					size += 1;
-					serializedEdges[index] = setBit(serializedEdges[index], pos);
-				}
-				done = true;
-				break;
-			}
-			i += Integer.SIZE / Byte.SIZE + 1;
-		}
-		if (!done) { // we need to add a bucket
-			serializedEdges = addBytes(serializedEdges, toByteArray(bucket), setBit((byte) 0, pos));
-			size += 1;
-		}
-	}
+  @Override
+  public void add(Edge<IntWritable, NullWritable> edge) {
+    int bucket = edge.getTargetVertexId().get() / Byte.SIZE;
+    int pos = edge.getTargetVertexId().get() % Byte.SIZE;
+    int i = 0;
+    boolean done = false;
+    while (i < serializedEdges.length) { // if bucket is already there, simply
+                                         // set the appropriate bit
+      if (fromByteArray(Arrays.copyOfRange(serializedEdges, i,
+          i + Integer.SIZE / Byte.SIZE)) == bucket) {
+        int index = i + Integer.SIZE / Byte.SIZE;
+        if (!isSet(serializedEdges[index], pos)) {
+          size += 1;
+          serializedEdges[index] = setBit(serializedEdges[index], pos);
+        }
+        done = true;
+        break;
+      }
+      i += Integer.SIZE / Byte.SIZE + 1;
+    }
+    if (!done) { // we need to add a bucket
+      serializedEdges = addBytes(serializedEdges, toByteArray(bucket),
+          setBit((byte) 0, pos));
+      size += 1;
+    }
+  }
 
-	@Override
-	public void remove(IntWritable targetVertexId) {
-		int bucket = targetVertexId.get() / Byte.SIZE;
-		int pos = targetVertexId.get() % Byte.SIZE;
-		int i = 0;
-		while (i < serializedEdges.length) {
-			if (fromByteArray(Arrays.copyOfRange(serializedEdges, i, i + Integer.SIZE / Byte.SIZE)) == bucket) {
-				serializedEdges[i + Integer.SIZE / Byte.SIZE] = unsetBit(serializedEdges[i + Integer.SIZE / Byte.SIZE],
-						pos);
-				--size;
-				break;
-			}
-			i += Integer.SIZE / Byte.SIZE + 1;
-		}
-	}
+  @Override
+  public void remove(IntWritable targetVertexId) {
+    int bucket = targetVertexId.get() / Byte.SIZE;
+    int pos = targetVertexId.get() % Byte.SIZE;
+    int i = 0;
+    while (i < serializedEdges.length) {
+      if (fromByteArray(Arrays.copyOfRange(serializedEdges, i,
+          i + Integer.SIZE / Byte.SIZE)) == bucket) {
+        serializedEdges[i + Integer.SIZE / Byte.SIZE] = unsetBit(
+            serializedEdges[i + Integer.SIZE / Byte.SIZE], pos);
+        --size;
+        break;
+      }
+      i += Integer.SIZE / Byte.SIZE + 1;
+    }
+  }
 
-	@Override
-	public int size() {
-		return size;
-	}
+  @Override
+  public int size() {
+    return size;
+  }
 
-	@Override
-	public void trim() {
-		// Nothing to do
-	}
-	
-	@Override
-	public Iterator<Edge<IntWritable, NullWritable>> iterator() {
-		if (size == 0) {
-			return ImmutableSet.<Edge<IntWritable, NullWritable>>of().iterator();
-		} else {
-			return new IndexedBitmapEdgeIterator();
-		}
-	}
+  @Override
+  public void trim() {
+    // Nothing to do
+  }
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		size = in.readInt();
-		int serializedEdgesBytesUsed = in.readInt();
-		if (serializedEdgesBytesUsed > 0) {
-			// Only create a new buffer if the old one isn't big enough
-			if (serializedEdges == null || serializedEdgesBytesUsed > serializedEdges.length) {
-				serializedEdges = new byte[serializedEdgesBytesUsed];
-			}
-			in.readFully(serializedEdges, 0, serializedEdgesBytesUsed);
-		}
-	}
+  @Override
+  public Iterator<Edge<IntWritable, NullWritable>> iterator() {
+    if (size == 0) {
+      return ImmutableSet.<Edge<IntWritable, NullWritable>>of().iterator();
+    } else {
+      return new IndexedBitmapEdgeIterator();
+    }
+  }
 
-	@Override
-	public void write(DataOutput out) throws IOException {
-		out.writeInt(size);
-		out.writeInt(serializedEdges.length);
-		if (serializedEdges.length > 0) {
-			out.write(serializedEdges, 0, serializedEdges.length);
-		}
-	}
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    size = in.readInt();
+    int serializedEdgesBytesUsed = in.readInt();
+    if (serializedEdgesBytesUsed > 0) {
+      // Only create a new buffer if the old one isn't big enough
+      if (serializedEdges == null ||
+          serializedEdgesBytesUsed > serializedEdges.length) {
+        serializedEdges = new byte[serializedEdgesBytesUsed];
+      }
+      in.readFully(serializedEdges, 0, serializedEdgesBytesUsed);
+    }
+  }
 
-	/** Iterator that reuses the same Edge object. */
-	private class IndexedBitmapEdgeIterator extends UnmodifiableIterator<Edge<IntWritable, NullWritable>> {
-		/** Representative edge object. */
-		private final Edge<IntWritable, NullWritable> representativeEdge = EdgeFactory.create(new IntWritable());
-		/** Current edge count */
-		private int currentEdge = 0;
-		/** Current position */
-		private int currentBitPosition = 0;
-		private int currentBytePosition = 0;
-		/** Index int */
-		private int indexInt;
-		/** Current byte */
-		private Byte myByte;
-		/** Current index */
-		private byte[] myBytes = new byte[Integer.SIZE / Byte.SIZE];
+  @Override
+  public void write(DataOutput out) throws IOException {
+    out.writeInt(size);
+    out.writeInt(serializedEdges.length);
+    if (serializedEdges.length > 0) {
+      out.write(serializedEdges, 0, serializedEdges.length);
+    }
+  }
 
-		@Override
-		public boolean hasNext() {
-			return currentEdge < size;
-		}
+  /** Iterator that reuses the same Edge object. */
+  private class IndexedBitmapEdgeIterator
+      extends UnmodifiableIterator<Edge<IntWritable, NullWritable>> {
+    /** Representative edge object. */
+    private final Edge<IntWritable, NullWritable> representativeEdge =
+        EdgeFactory.create(new IntWritable());
+    /** Current edge count */
+    private int currentEdge = 0;
+    /** Current bit position */
+    private int currentBitPosition = 0;
+    /** Current byte position */
+    private int currentBytePosition = 0;
+    /** Index int */
+    private int indexInt;
+    /** Current byte */
+    private Byte myByte;
+    /** Current index */
+    private byte[] myBytes = new byte[Integer.SIZE / Byte.SIZE];
 
-		@Override
-		public Edge<IntWritable, NullWritable> next() {
-			if (currentBitPosition == 8) {
-				currentBitPosition = 0;
-			}
-			if (currentBitPosition == 0) {
-				myBytes[0] = serializedEdges[currentBytePosition];
-				myBytes[1] = serializedEdges[currentBytePosition + 1];
-				myBytes[2] = serializedEdges[currentBytePosition + 2];
-				myBytes[3] = serializedEdges[currentBytePosition + 3];
-				indexInt = fromByteArray(myBytes);
-				myByte = serializedEdges[currentBytePosition + Integer.SIZE / Byte.SIZE];
-				currentBytePosition += Integer.SIZE / Byte.SIZE + 1;
-			}
-			int pos = currentBitPosition;
-			int nextPos = 0;
-			boolean done = false;
-			while (!done) {
-				for (int i = pos; i < Byte.SIZE; i++) {
-					if (isSet(myByte, i)) {
-						done = true;
-						nextPos = i;
-						currentEdge++;
-						currentBitPosition = i + 1;
-						break;
-					}
-				}
-				if (!done /* && mapIterator.hasNext() */) {
-					myBytes[0] = serializedEdges[currentBytePosition];
-					myBytes[1] = serializedEdges[currentBytePosition + 1];
-					myBytes[2] = serializedEdges[currentBytePosition + 2];
-					myBytes[3] = serializedEdges[currentBytePosition + 3];
-					indexInt = fromByteArray(myBytes);
-					myByte = serializedEdges[currentBytePosition + Integer.SIZE / Byte.SIZE];
-					currentBytePosition += Integer.SIZE / Byte.SIZE + 1;
-					pos = 0;
-				}
-			}
-			representativeEdge.getTargetVertexId().set(indexInt * Byte.SIZE + nextPos);
-			return representativeEdge;
-		}
+    @Override
+    public boolean hasNext() {
+      return currentEdge < size;
+    }
 
-	}
+    @Override
+    public Edge<IntWritable, NullWritable> next() {
+      if (currentBitPosition == 8) {
+        currentBitPosition = 0;
+      }
+      if (currentBitPosition == 0) {
+        myBytes[0] = serializedEdges[currentBytePosition];
+        myBytes[1] = serializedEdges[currentBytePosition + 1];
+        myBytes[2] = serializedEdges[currentBytePosition + 2];
+        myBytes[3] = serializedEdges[currentBytePosition + 3];
+        indexInt = fromByteArray(myBytes);
+        myByte = serializedEdges[currentBytePosition +
+                                 Integer.SIZE / Byte.SIZE];
+        currentBytePosition += Integer.SIZE / Byte.SIZE + 1;
+      }
+      int pos = currentBitPosition;
+      int nextPos = 0;
+      boolean done = false;
+      while (!done) {
+        for (int i = pos; i < Byte.SIZE; i++) {
+          if (isSet(myByte, i)) {
+            done = true;
+            nextPos = i;
+            currentEdge++;
+            currentBitPosition = i + 1;
+            break;
+          }
+        }
+        if (!done /* && mapIterator.hasNext() */) {
+          myBytes[0] = serializedEdges[currentBytePosition];
+          myBytes[1] = serializedEdges[currentBytePosition + 1];
+          myBytes[2] = serializedEdges[currentBytePosition + 2];
+          myBytes[3] = serializedEdges[currentBytePosition + 3];
+          indexInt = fromByteArray(myBytes);
+          myByte = serializedEdges[currentBytePosition +
+                                   Integer.SIZE / Byte.SIZE];
+          currentBytePosition += Integer.SIZE / Byte.SIZE + 1;
+          pos = 0;
+        }
+      }
+      representativeEdge.getTargetVertexId()
+          .set(indexInt * Byte.SIZE + nextPos);
+      return representativeEdge;
+    }
 
-	/**
-	 * tests if bit is set in a byte
-	 * 
-	 * @param myByte the byte to be tested
-	 * @param pos    the position in the byte to be tested
-	 * @returns true or false depending on the bit being set
-	 * 
-	 */
-	public static boolean isSet(byte myByte, int pos) {
-		return (myByte & (1 << pos)) != 0;
-	}
+  }
 
-	/**
-	 * tests if bit is set in a byte
-	 * 
-	 * @param byteWritable the byte to be updated
-	 * @param pos          the position in the byte to be set
-	 * @returns the updated byte
-	 * 
-	 */
-	public static byte setBit(byte myByte, int pos) {
-		return (byte) (myByte | (1 << pos));
-	}
+  /**
+   * tests if bit is set in a byte
+   *
+   * @param myByte the byte to be tested
+   * @param pos    the position in the byte to be tested
+   * @return true or false depending on the bit being set
+   *
+   */
+  public static boolean isSet(byte myByte, int pos) {
+    return (myByte & (1 << pos)) != 0;
+  }
 
-	/**
-	 * tests if bit is set in a byte
-	 * 
-	 * @param my_byte the byte to be updated
-	 * @param pos     the position in the byte to be unset
-	 * @returns the updated byte
-	 * 
-	 */
-	public static byte unsetBit(byte myByte, int pos) {
-		return (byte) (myByte & ~(1 << pos));
-	}
+  /**
+   * tests if bit is set in a byte
+   *
+   * @param myByte the byte to be updated
+   * @param pos    the position in the byte to be set
+   * @return the updated byte
+   *
+   */
+  public static byte setBit(byte myByte, int pos) {
+    return (byte) (myByte | (1 << pos));
+  }
 
-	/**
-	 * converts an integer to a 4-byte length array holding
-	 * its binary representation
-	 * 
-	 * @param value the integer to be converted
-	 * @return the 4-byte length byte array holding the integer's
-	 * binary representation
-	 */
-	public static byte[] toByteArray(int value) {
-		return new byte[] { (byte) (value >> 24), (byte) (value >> 16), (byte) (value >> 8), (byte) value };
-	}
+  /**
+   * tests if bit is set in a byte
+   *
+   * @param myByte the byte to be updated
+   * @param pos     the position in the byte to be unset
+   * @return the updated byte
+   *
+   */
+  public static byte unsetBit(byte myByte, int pos) {
+    return (byte) (myByte & ~(1 << pos));
+  }
 
-	/**
-	 * converts a 4-byte length byte array to its respective integer
-	 * 
-	 * @param bytes a 4-byte length byte array
-	 * @return the integer represented in the byte array
-	 */
-	public static int fromByteArray(byte[] bytes) {
-		return bytes[0] << 24 | (bytes[1] & 0xFF) << 16 | (bytes[2] & 0xFF) << 8 | (bytes[3] & 0xFF);
-	}
+  /**
+   * converts an integer to a 4-byte length array holding its binary
+   * representation
+   *
+   * @param value the integer to be converted
+   * @return the 4-byte length byte array holding the integer's binary
+   *         representation
+   */
+  public static byte[] toByteArray(int value) {
+    return new byte[] { (byte) (value >> 24), (byte) (value >> 16),
+      (byte) (value >> 8), (byte) value };
+  }
 
-	/**
-	 * returns a byte array with the concatenation of the three input parameters
-	 * 
-	 * @param original a byte array
-	 * @param bindex a byte array
-	 * @param myByte a byte
-	 * @return a byte array with the concatenation of the three input parameters
-	 * */
-	public static byte[] addBytes(byte[] original, byte[] bindex, byte myByte) {
-		byte[] destination = new byte[original.length + Integer.SIZE / Byte.SIZE + 1];
-		System.arraycopy(original, 0, destination, 0, original.length);
-		System.arraycopy(bindex, 0, destination, original.length, Integer.SIZE / Byte.SIZE);
-		destination[destination.length - 1] = myByte;
-		return destination;
-	}
+  /**
+   * converts a 4-byte length byte array to its respective integer
+   *
+   * @param bytes a 4-byte length byte array
+   * @return the integer represented in the byte array
+   */
+  public static int fromByteArray(byte[] bytes) {
+    return bytes[0] << 24 | (bytes[1] & 0xFF) << 16 | (bytes[2] & 0xFF) << 8 |
+      (bytes[3] & 0xFF);
+  }
+
+  /**
+   * returns a byte array with the concatenation of the three input parameters
+   *
+   * @param original a byte array
+   * @param bindex   a byte array
+   * @param myByte   a byte
+   * @return a byte array with the concatenation of the three input parameters
+   */
+  public static byte[] addBytes(byte[] original, byte[] bindex, byte myByte) {
+    byte[] destination = new byte[original.length + Integer.SIZE / Byte.SIZE +
+                                  1];
+    System.arraycopy(original, 0, destination, 0, original.length);
+    System.arraycopy(bindex, 0, destination, original.length,
+        Integer.SIZE / Byte.SIZE);
+    destination[destination.length - 1] = myByte;
+    return destination;
+  }
 
 }

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IndexedBitArrayEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IndexedBitArrayEdges.java
@@ -34,10 +34,13 @@ import java.util.stream.StreamSupport;
 
 /**
  * Implementation of {@link OutEdges} with int ids and null edge values, backed
- * by the IndexedBitArrayEdges structure proposed in "Panagiotis Liakos, Katia
- * Papakonstantinopoulou, Alex Delis: Realizing Memory-Optimized Distributed
- * Graph Processing. IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018)". Note:
- * this implementation is optimized for space usage for graphs exhibiting the
+ * by the IndexedBitArrayEdges structure proposed in:
+ * 
+ * Panagiotis Liakos, Katia Papakonstantinopoulou, Alex Delis:
+ * Realizing Memory-Optimized Distributed Graph Processing.
+ * IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018).
+ * 
+ * Note: this implementation is optimized for space usage for graphs exhibiting the
  * locality of reference property, but edge addition and
  * removals are expensive. Parallel edges are ignored.
  */

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IndexedBitArrayEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IndexedBitArrayEdges.java
@@ -24,7 +24,6 @@ import com.google.common.collect.UnmodifiableIterator;
 import org.apache.giraph.utils.Trimmable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.NullWritable;
-import org.python.google.common.primitives.Bytes;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -40,7 +39,7 @@ import java.util.stream.StreamSupport;
  * Graph Processing. IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018)". Note:
  * this implementation is optimized for space usage for graphs exhibiting the
  * locality of reference property, but edge addition and
- * removals are expensive. Parallel edges are not allowed.
+ * removals are expensive. Parallel edges are ignored.
  */
 public class IndexedBitArrayEdges extends ConfigurableOutEdges<IntWritable, NullWritable>
 		implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
@@ -40,10 +40,13 @@ import com.google.common.collect.UnmodifiableIterator;
 
 /**
  * Implementation of {@link OutEdges} with int ids and null edge values, backed
- * by the IntervalResidualEdges structure proposed in "Panagiotis Liakos, Katia
- * Papakonstantinopoulou, Alex Delis: Realizing Memory-Optimized Distributed
- * Graph Processing. IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018)". Note:
- * this implementation is optimized for space usage for graphs exhibiting the
+ * by the IntervalResidualEdges structure proposed in:
+ * 
+ * Panagiotis Liakos, Katia Papakonstantinopoulou, Alex Delis:
+ * Realizing Memory-Optimized Distributed Graph Processing.
+ * IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018).
+ * 
+ * Note: this implementation is optimized for space usage for graphs exhibiting the
  * locality of reference property, but edge addition and
  * removals are expensive. Parallel edges are not allowed.
  */

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
@@ -43,7 +43,8 @@ import com.google.common.collect.UnmodifiableIterator;
  * by the IntervalResidualEdges structure proposed in "Panagiotis Liakos, Katia
  * Papakonstantinopoulou, Alex Delis: Realizing Memory-Optimized Distributed
  * Graph Processing. IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018)". Note:
- * this implementation is optimized for space usage, but edge addition and
+ * this implementation is optimized for space usage for graphs exhibiting the
+ * locality of reference property, but edge addition and
  * removals are expensive. Parallel edges are not allowed.
  */
 public class IntervalResidualEdges extends ConfigurableOutEdges<IntWritable, NullWritable>

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
@@ -25,15 +25,14 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.stream.StreamSupport;
 
 import org.apache.giraph.utils.ExtendedDataInput;
 import org.apache.giraph.utils.ExtendedDataOutput;
 import org.apache.giraph.utils.Trimmable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.NullWritable;
-import org.weakref.jmx.com.google.common.collect.Iterators;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.UnmodifiableIterator;
@@ -41,205 +40,237 @@ import com.google.common.collect.UnmodifiableIterator;
 /**
  * Implementation of {@link OutEdges} with int ids and null edge values, backed
  * by the IntervalResidualEdges structure proposed in:
- * 
+ *
  * Panagiotis Liakos, Katia Papakonstantinopoulou, Alex Delis:
  * Realizing Memory-Optimized Distributed Graph Processing.
  * IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018).
- * 
- * Note: this implementation is optimized for space usage for graphs exhibiting the
- * locality of reference property, but edge addition and
- * removals are expensive. Parallel edges are not allowed.
+ *
+ * Note: this implementation is optimized for space usage for graphs exhibiting
+ * the locality of reference property, but edge addition and removals are
+ * expensive. Parallel edges are not allowed.
  */
-public class IntervalResidualEdges extends ConfigurableOutEdges<IntWritable, NullWritable>
-		implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {
+public class IntervalResidualEdges
+    extends ConfigurableOutEdges<IntWritable, NullWritable>
+    implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {
 
-	/** Minimum interval length is equal to 2 */
-	private static final int MIN_INTERVAL_LENGTH = 2;
-	
-	/** Maximum interval length is equal to 254 */
-	private static final int MAX_INTERVAL_LENGTH = 254;
-	
-	/** Serialized Intervals and Residuals */
-	private byte[] intervalsAndResiduals;
+  /** Minimum interval length is equal to 2 */
+  private static final int MIN_INTERVAL_LENGTH = 2;
 
-	/** Number of edges stored in compressed array */
-	private int size;
+  /** Maximum interval length is equal to 254 */
+  private static final int MAX_INTERVAL_LENGTH = 254;
 
-	@Override
-	public void initialize(Iterable<Edge<IntWritable, NullWritable>> edges) {
-		compress(StreamSupport.stream(edges.spliterator(), false).map(Edge::getTargetVertexId).mapToInt(IntWritable::get).toArray());
-	}
-	
-	@Override
-	public void initialize(int capacity) {
-		size = 0;
-		intervalsAndResiduals = null;
-	}
+  /** Serialized Intervals and Residuals */
+  private byte[] intervalsAndResiduals;
 
-	@Override
-	public void initialize() {
-		size = 0;
-		intervalsAndResiduals = null;
-	}
+  /** Number of edges stored in compressed array */
+  private int size;
 
-	@Override
-	public void add(Edge<IntWritable, NullWritable> edge) {
-	    // Note that this is very expensive (decompresses all edges and recompresses them again).
-		compress(StreamSupport.stream(((Iterable<Edge<IntWritable, NullWritable>>)() -> Iterators.concat(this.iterator(), ImmutableSet.of(edge).iterator())).spliterator(), false).map(Edge::getTargetVertexId).mapToInt(IntWritable::get).sorted().toArray());
-	}
+  @Override
+  public void initialize(Iterable<Edge<IntWritable, NullWritable>> edges) {
+    IntArrayList edgesList = new IntArrayList();
+    for (Iterator<Edge<IntWritable, NullWritable>> iter = edges.iterator(); iter
+        .hasNext();) {
+      edgesList.add(iter.next().getTargetVertexId().get());
+    }
+    compress(Arrays.copyOfRange(edgesList.elements(), 0, edgesList.size()));
+  }
 
-	@Override
-	public void remove(IntWritable targetVertexId) {
-	    // Note that this is very expensive (decompresses all edges and recompresses them again).
-		initialize(Iterables.filter(this, edge -> !edge.getTargetVertexId().equals(targetVertexId)));
-	}
+  @Override
+  public void initialize(int capacity) {
+    size = 0;
+    intervalsAndResiduals = null;
+  }
 
-	@Override
-	public int size() {
-		return size;
-	}
+  @Override
+  public void initialize() {
+    size = 0;
+    intervalsAndResiduals = null;
+  }
 
-	@Override
-	public Iterator<Edge<IntWritable, NullWritable>> iterator() {
-		if (size == 0) {
-			return ImmutableSet.<Edge<IntWritable, NullWritable>>of().iterator();
-		} else {
-			return new IntervalResidualEdgeIterator();
-		}
-	}
+  @Override
+  public void add(Edge<IntWritable, NullWritable> edge) {
+    // Note that this is very expensive (decompresses all edges and recompresses
+    // them again).
+    IntArrayList edgesList = new IntArrayList();
+    for (Iterator<Edge<IntWritable, NullWritable>> iter = this.iterator(); iter
+        .hasNext();) {
+      edgesList.add(iter.next().getTargetVertexId().get());
+    }
+    edgesList.add(edge.getTargetVertexId().get());
+    compress(Arrays.copyOfRange(edgesList.elements(), 0, edgesList.size()));
+  }
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		size = in.readInt();
-		int intervalResidualEdgesBytesUsed = in.readInt();
-		if (intervalResidualEdgesBytesUsed > 0) {
-			// Only create a new buffer if the old one isn't big enough
-			if (intervalsAndResiduals == null || intervalResidualEdgesBytesUsed > intervalsAndResiduals.length) {
-				intervalsAndResiduals = new byte[intervalResidualEdgesBytesUsed];
-			}
-			in.readFully(intervalsAndResiduals, 0, intervalResidualEdgesBytesUsed);
-		}
-	}
+  @Override
+  public void remove(IntWritable targetVertexId) {
+    // Note that this is very expensive (decompresses all edges and recompresses
+    // them again).
+    final int id = targetVertexId.get();
+    initialize(Iterables.filter(this,
+        new Predicate<Edge<IntWritable, NullWritable>>() {
+          @Override
+          public boolean apply(Edge<IntWritable, NullWritable> edge) {
+            return edge.getTargetVertexId().get() != id;
+          }
+        }));
+  }
 
-	@Override
-	public void write(DataOutput out) throws IOException {
-		out.writeInt(size);
-		out.writeInt(intervalsAndResiduals.length);
-		if (intervalsAndResiduals.length > 0) {
-			out.write(intervalsAndResiduals, 0, intervalsAndResiduals.length);
-		}
-	}
+  @Override
+  public int size() {
+    return size;
+  }
 
-	@Override
-	public void trim() {
-		/* Nothing to do */
-	}
-	
-	/** Receives an integer array of successors and compresses them
-	 * in the intervalsAndResiduals byte array 
-	 * 
-	 * @param edgesArray an integer array of successors
-	 * */
-	private void compress(final int[] edgesArray) {
-		try {
-			ExtendedDataOutput eos = getConf().createExtendedDataOutput();
-			IntArrayList left = new IntArrayList();
-			IntArrayList len = new IntArrayList();
-			IntArrayList residuals = new IntArrayList();
-			// If we are to produce intervals, we first compute them.
-			int intervalCount;
-			try {
-				intervalCount = BVEdges.intervalize(edgesArray, MIN_INTERVAL_LENGTH, MAX_INTERVAL_LENGTH, left, len,
-						residuals);
-			} catch (IllegalArgumentException e) {
-				// array was not sorted, sorting and retrying
-				Arrays.sort(edgesArray);
-				left = new IntArrayList();
-				len = new IntArrayList();
-				residuals = new IntArrayList();
-				intervalCount = BVEdges.intervalize(edgesArray, MIN_INTERVAL_LENGTH, MAX_INTERVAL_LENGTH, left, len,
-						residuals);
-			}
+  @Override
+  public Iterator<Edge<IntWritable, NullWritable>> iterator() {
+    if (size == 0) {
+      return ImmutableSet.<Edge<IntWritable, NullWritable>>of().iterator();
+    } else {
+      return new IntervalResidualEdgeIterator();
+    }
+  }
 
-			// We write out the intervals.
-			eos.writeInt(intervalCount);
-			for (int i = 0; i < intervalCount; i++) {
-				eos.writeInt(left.getInt(i));
-				eos.write(len.getInt(i));
-			}
-			final int[] residual = residuals.elements();
-			final int residualCount = residuals.size();
-			for (int i = 0; i < residualCount; i++) {
-				eos.writeInt(residual[i]);
-			}
-			intervalsAndResiduals = eos.toByteArray();
-			size = edgesArray.length;
-		} catch (IOException e) {
-			throw new IllegalArgumentException(e);
-		}
-	}
-	
-	/**
-	 * Iterator that reuses the same Edge object.
-	 */
-	private class IntervalResidualEdgeIterator extends UnmodifiableIterator<Edge<IntWritable, NullWritable>> {
-		private ExtendedDataInput extendedDataInput = getConf().createExtendedDataInput(intervalsAndResiduals, 0,
-				intervalsAndResiduals.length);
-		/** Representative edge object. */
-		private final Edge<IntWritable, NullWritable> representativeEdge = EdgeFactory.create(new IntWritable());
-		/** Current edge count */
-		private int currentEdge = 0;
-		private int currentLeft;
-		private int currentLen = 0;
-		private int intervalCount;
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    size = in.readInt();
+    int intervalResidualEdgesBytesUsed = in.readInt();
+    if (intervalResidualEdgesBytesUsed > 0) {
+      // Only create a new buffer if the old one isn't big enough
+      if (intervalsAndResiduals == null ||
+          intervalResidualEdgesBytesUsed > intervalsAndResiduals.length) {
+        intervalsAndResiduals = new byte[intervalResidualEdgesBytesUsed];
+      }
+      in.readFully(intervalsAndResiduals, 0, intervalResidualEdgesBytesUsed);
+    }
+  }
 
-		public IntervalResidualEdgeIterator() {
-			try {
-				intervalCount = extendedDataInput.readInt();
-			} catch (IOException e) {
-				throw new IllegalStateException(e);
-			}
-		}
+  @Override
+  public void write(DataOutput out) throws IOException {
+    out.writeInt(size);
+    out.writeInt(intervalsAndResiduals.length);
+    if (intervalsAndResiduals.length > 0) {
+      out.write(intervalsAndResiduals, 0, intervalsAndResiduals.length);
+    }
+  }
 
-		@Override
-		public boolean hasNext() {
-			return currentEdge < size;
-		}
+  @Override
+  public void trim() {
+    /* Nothing to do */
+  }
 
-		@Override
-		public Edge<IntWritable, NullWritable> next() {
-			this.currentEdge++;
-			switch (this.currentLen) {
-			case 0:
-				switch (this.intervalCount) {
-				case 0:
-					try {
-						representativeEdge.getTargetVertexId().set(extendedDataInput.readInt());
-					} catch (IOException canthappen) {
-						throw new IllegalStateException(canthappen);
-					}
-					return representativeEdge;
-				default:
-					try {
-						this.currentLeft = extendedDataInput.readInt();
-						this.currentLen = extendedDataInput.readByte() & 0xff;
-						intervalCount--;
-					} catch (IOException canthappen) {
-						throw new IllegalStateException(canthappen);
-					}
-					final int result = this.currentLeft;
-					this.currentLen--;
-					representativeEdge.getTargetVertexId().set(result);
-					return representativeEdge;
+  /**
+   * Receives an integer array of successors and compresses them in the
+   * intervalsAndResiduals byte array
+   *
+   * @param edgesArray an integer array of successors
+   */
+  private void compress(final int[] edgesArray) {
+    try {
+      ExtendedDataOutput eos = getConf().createExtendedDataOutput();
+      IntArrayList left = new IntArrayList();
+      IntArrayList len = new IntArrayList();
+      IntArrayList residuals = new IntArrayList();
+      // If we are to produce intervals, we first compute them.
+      int intervalCount;
+      try {
+        intervalCount = BVEdges.intervalize(edgesArray, MIN_INTERVAL_LENGTH,
+            MAX_INTERVAL_LENGTH, left, len, residuals);
+      } catch (IllegalArgumentException e) {
+        // array was not sorted, sorting and retrying
+        Arrays.sort(edgesArray);
+        left = new IntArrayList();
+        len = new IntArrayList();
+        residuals = new IntArrayList();
+        intervalCount = BVEdges.intervalize(edgesArray, MIN_INTERVAL_LENGTH,
+            MAX_INTERVAL_LENGTH, left, len, residuals);
+      }
 
-				}
-			default:
-				final int result = ++this.currentLeft;
-				this.currentLen--;
-				representativeEdge.getTargetVertexId().set(result);
-				return representativeEdge;
-			}
-		}
+      // We write out the intervals.
+      eos.writeInt(intervalCount);
+      for (int i = 0; i < intervalCount; i++) {
+        eos.writeInt(left.getInt(i));
+        eos.write(len.getInt(i));
+      }
+      final int[] residual = residuals.elements();
+      final int residualCount = residuals.size();
+      for (int i = 0; i < residualCount; i++) {
+        eos.writeInt(residual[i]);
+      }
+      intervalsAndResiduals = eos.toByteArray();
+      size = edgesArray.length;
+    } catch (IOException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
 
-	}
+  /**
+   * Iterator that reuses the same Edge object.
+   */
+  private class IntervalResidualEdgeIterator
+      extends UnmodifiableIterator<Edge<IntWritable, NullWritable>> {
+    /** Input for processing the bytes */
+    private ExtendedDataInput extendedDataInput = getConf()
+        .createExtendedDataInput(intervalsAndResiduals, 0,
+            intervalsAndResiduals.length);
+    /** Representative edge object. */
+    private final Edge<IntWritable, NullWritable> representativeEdge =
+        EdgeFactory.create(new IntWritable());
+    /** Current edge count */
+    private int currentEdge = 0;
+    /** Current interval index */
+    private int currentLeft;
+    /** Current interval length */
+    private int currentLen = 0;
+    /** Interval counter initialized with interval size and counting down */
+    private int intervalCount;
+
+    /** Constructor */
+    public IntervalResidualEdgeIterator() {
+      try {
+        intervalCount = extendedDataInput.readInt();
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return currentEdge < size;
+    }
+
+    @Override
+    public Edge<IntWritable, NullWritable> next() {
+      this.currentEdge++;
+      switch (this.currentLen) {
+      case 0:
+        switch (this.intervalCount) {
+        case 0:
+          try {
+            representativeEdge.getTargetVertexId()
+                .set(extendedDataInput.readInt());
+          } catch (IOException canthappen) {
+            throw new IllegalStateException(canthappen);
+          }
+          return representativeEdge;
+        default:
+          try {
+            this.currentLeft = extendedDataInput.readInt();
+            this.currentLen = extendedDataInput.readByte() & 0xff;
+            intervalCount--;
+          } catch (IOException canthappen) {
+            throw new IllegalStateException(canthappen);
+          }
+          final int result = this.currentLeft;
+          this.currentLen--;
+          representativeEdge.getTargetVertexId().set(result);
+          return representativeEdge;
+
+        }
+      default:
+        final int result = ++this.currentLeft;
+        this.currentLen--;
+        representativeEdge.getTargetVertexId().set(result);
+        return representativeEdge;
+      }
+    }
+
+  }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.giraph.edge;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
@@ -1,0 +1,224 @@
+package org.apache.giraph.edge;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.stream.StreamSupport;
+
+import org.apache.giraph.utils.ExtendedDataInput;
+import org.apache.giraph.utils.ExtendedDataOutput;
+import org.apache.giraph.utils.Trimmable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.weakref.jmx.com.google.common.collect.Iterators;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.UnmodifiableIterator;
+
+/**
+ * Implementation of {@link OutEdges} with int ids and null edge values, backed
+ * by the IntervalResidualEdges structure proposed in "Panagiotis Liakos, Katia
+ * Papakonstantinopoulou, Alex Delis: Realizing Memory-Optimized Distributed
+ * Graph Processing. IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018)". Note:
+ * this implementation is optimized for space usage, but edge addition and
+ * removals are expensive. Parallel edges are not allowed.
+ */
+public class IntervalResidualEdges extends ConfigurableOutEdges<IntWritable, NullWritable>
+		implements ReuseObjectsOutEdges<IntWritable, NullWritable>, Trimmable {
+
+	/** Minimum interval length is equal to 2 */
+	private static final int MIN_INTERVAL_LENGTH = 2;
+	
+	/** Maximum interval length is equal to 254 */
+	private static final int MAX_INTERVAL_LENGTH = 254;
+	
+	/** Serialized Intervals and Residuals */
+	private byte[] intervalsAndResiduals;
+
+	/** Number of edges stored in compressed array */
+	private int size;
+
+	@Override
+	public void initialize(Iterable<Edge<IntWritable, NullWritable>> edges) {
+		compress(StreamSupport.stream(edges.spliterator(), false).map(Edge::getTargetVertexId).mapToInt(IntWritable::get).toArray());
+	}
+	
+	@Override
+	public void initialize(int capacity) {
+		size = 0;
+		intervalsAndResiduals = null;
+	}
+
+	@Override
+	public void initialize() {
+		size = 0;
+		intervalsAndResiduals = null;
+	}
+
+	@Override
+	public void add(Edge<IntWritable, NullWritable> edge) {
+	    // Note that this is very expensive (decompresses all edges and recompresses them again).
+		compress(StreamSupport.stream(((Iterable<Edge<IntWritable, NullWritable>>)() -> Iterators.concat(this.iterator(), ImmutableSet.of(edge).iterator())).spliterator(), false).map(Edge::getTargetVertexId).mapToInt(IntWritable::get).sorted().toArray());
+	}
+
+	@Override
+	public void remove(IntWritable targetVertexId) {
+	    // Note that this is very expensive (decompresses all edges and recompresses them again).
+		initialize(Iterables.filter(this, edge -> !((Edge<IntWritable, NullWritable>) edge).getTargetVertexId().equals(targetVertexId)));
+	}
+
+	@Override
+	public int size() {
+		return size;
+	}
+
+	@Override
+	public Iterator<Edge<IntWritable, NullWritable>> iterator() {
+		if (size == 0) {
+			return ImmutableSet.<Edge<IntWritable, NullWritable>>of().iterator();
+		} else {
+			return new IntervalResidualEdgeIterator();
+		}
+	}
+
+	@Override
+	public void readFields(DataInput in) throws IOException {
+		size = in.readInt();
+		int intervalResidualEdgesBytesUsed = in.readInt();
+		if (intervalResidualEdgesBytesUsed > 0) {
+			// Only create a new buffer if the old one isn't big enough
+			if (intervalsAndResiduals == null || intervalResidualEdgesBytesUsed > intervalsAndResiduals.length) {
+				intervalsAndResiduals = new byte[intervalResidualEdgesBytesUsed];
+			}
+			in.readFully(intervalsAndResiduals, 0, intervalResidualEdgesBytesUsed);
+		}
+	}
+
+	@Override
+	public void write(DataOutput out) throws IOException {
+		out.writeInt(size);
+		out.writeInt(intervalsAndResiduals.length);
+		if (intervalsAndResiduals.length > 0) {
+			out.write(intervalsAndResiduals, 0, intervalsAndResiduals.length);
+		}
+	}
+
+	@Override
+	public void trim() {
+		/* Nothing to do */
+	}
+	
+	/** Receives an integer array of successors and compresses them
+	 * in the intervalsAndResiduals byte array 
+	 * 
+	 * @param edgesArray an integer array of successors
+	 * */
+	private void compress(final int[] edgesArray) {
+		try {
+			ExtendedDataOutput eos = getConf().createExtendedDataOutput();
+			IntArrayList left = new IntArrayList();
+			IntArrayList len = new IntArrayList();
+			IntArrayList residuals = new IntArrayList();
+			// If we are to produce intervals, we first compute them.
+			int intervalCount;
+			try {
+				intervalCount = BVEdges.intervalize(edgesArray, MIN_INTERVAL_LENGTH, MAX_INTERVAL_LENGTH, left, len,
+						residuals);
+			} catch (IllegalArgumentException e) {
+				// array was not sorted, sorting and retrying
+				Arrays.sort(edgesArray);
+				left = new IntArrayList();
+				len = new IntArrayList();
+				residuals = new IntArrayList();
+				intervalCount = BVEdges.intervalize(edgesArray, MIN_INTERVAL_LENGTH, MAX_INTERVAL_LENGTH, left, len,
+						residuals);
+			}
+
+			// We write out the intervals.
+			eos.writeInt(intervalCount);
+			for (int i = 0; i < intervalCount; i++) {
+				eos.writeInt(left.getInt(i));
+				eos.write(len.getInt(i));
+			}
+			final int[] residual = residuals.elements();
+			final int residualCount = residuals.size();
+			for (int i = 0; i < residualCount; i++) {
+				eos.writeInt(residual[i]);
+			}
+			intervalsAndResiduals = eos.toByteArray();
+			size = edgesArray.length;
+		} catch (IOException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+	
+	/**
+	 * Iterator that reuses the same Edge object.
+	 */
+	private class IntervalResidualEdgeIterator extends UnmodifiableIterator<Edge<IntWritable, NullWritable>> {
+		private ExtendedDataInput extendedDataInput = getConf().createExtendedDataInput(intervalsAndResiduals, 0,
+				intervalsAndResiduals.length);
+		/** Representative edge object. */
+		private final Edge<IntWritable, NullWritable> representativeEdge = EdgeFactory.create(new IntWritable());
+		/** Current edge count */
+		private int currentEdge = 0;
+		private int currentLeft;
+		private int currentLen = 0;
+		private int intervalCount;
+
+		public IntervalResidualEdgeIterator() {
+			try {
+				intervalCount = extendedDataInput.readInt();
+			} catch (IOException e) {
+				throw new IllegalStateException(e);
+			}
+		}
+
+		@Override
+		public boolean hasNext() {
+			return currentEdge < size;
+		}
+
+		@Override
+		public Edge<IntWritable, NullWritable> next() {
+			this.currentEdge++;
+			switch (this.currentLen) {
+			case 0:
+				switch (this.intervalCount) {
+				case 0:
+					try {
+						representativeEdge.getTargetVertexId().set(extendedDataInput.readInt());
+					} catch (IOException canthappen) {
+						canthappen.printStackTrace();
+					}
+					return representativeEdge;
+				default:
+					try {
+						this.currentLeft = extendedDataInput.readInt();
+						this.currentLen = extendedDataInput.readByte() & 0xff;
+						intervalCount--;
+					} catch (IOException canthappen) {
+						canthappen.printStackTrace();
+					}
+					final int result = this.currentLeft;
+					this.currentLen--;
+					representativeEdge.getTargetVertexId().set(result);
+					return representativeEdge;
+
+				}
+			default:
+				final int result = ++this.currentLeft;
+				this.currentLen--;
+				representativeEdge.getTargetVertexId().set(result);
+				return representativeEdge;
+			}
+
+		}
+
+	}
+}

--- a/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
+++ b/giraph-core/src/main/java/org/apache/giraph/edge/IntervalResidualEdges.java
@@ -69,7 +69,7 @@ public class IntervalResidualEdges extends ConfigurableOutEdges<IntWritable, Nul
 	@Override
 	public void remove(IntWritable targetVertexId) {
 	    // Note that this is very expensive (decompresses all edges and recompresses them again).
-		initialize(Iterables.filter(this, edge -> !((Edge<IntWritable, NullWritable>) edge).getTargetVertexId().equals(targetVertexId)));
+		initialize(Iterables.filter(this, edge -> !edge.getTargetVertexId().equals(targetVertexId)));
 	}
 
 	@Override
@@ -194,7 +194,7 @@ public class IntervalResidualEdges extends ConfigurableOutEdges<IntWritable, Nul
 					try {
 						representativeEdge.getTargetVertexId().set(extendedDataInput.readInt());
 					} catch (IOException canthappen) {
-						canthappen.printStackTrace();
+						throw new IllegalStateException(canthappen);
 					}
 					return representativeEdge;
 				default:
@@ -203,7 +203,7 @@ public class IntervalResidualEdges extends ConfigurableOutEdges<IntWritable, Nul
 						this.currentLen = extendedDataInput.readByte() & 0xff;
 						intervalCount--;
 					} catch (IOException canthappen) {
-						canthappen.printStackTrace();
+						throw new IllegalStateException(canthappen);
 					}
 					final int result = this.currentLeft;
 					this.currentLen--;
@@ -217,7 +217,6 @@ public class IntervalResidualEdges extends ConfigurableOutEdges<IntWritable, Nul
 				representativeEdge.getTargetVertexId().set(result);
 				return representativeEdge;
 			}
-
 		}
 
 	}

--- a/giraph-core/src/test/java/org/apache/giraph/edge/BVEdgesEdgesTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/edge/BVEdgesEdgesTest.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.giraph.edge;
+
+import com.google.common.collect.Lists;
+import org.apache.giraph.conf.GiraphConfiguration;
+import org.apache.giraph.conf.GiraphConstants;
+import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Implementation of {@link OutEdges} with int ids and null edge values, backed
+ * by the BVEdges structure proposed in "Panagiotis Liakos, Katia
+ * Papakonstantinopoulou, Alex Delis: Realizing Memory-Optimized Distributed
+ * Graph Processing. IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018)". Note:
+ * this implementation is optimized for space usage, but edge addition and
+ * removals are expensive. Parallel edges are not allowed.
+ */
+public class BVEdgesEdgesTest {
+	private static Edge<IntWritable, NullWritable> createEdge(int id) {
+		return EdgeFactory.create(new IntWritable(id));
+	}
+
+	private static void assertEdges(BVEdges edges, int... expected) {
+		int index = 0;
+		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+			Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
+			index++;
+		}
+		Assert.assertEquals(expected.length, index);
+	}
+
+	private BVEdges getEdges() {
+		GiraphConfiguration gc = new GiraphConfiguration();
+		GiraphConstants.VERTEX_ID_CLASS.set(gc, IntWritable.class);
+		GiraphConstants.EDGE_VALUE_CLASS.set(gc, NullWritable.class);
+		ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable> conf = new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
+				gc);
+		BVEdges ret = new BVEdges();
+		ret.setConf(new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(conf));
+		return ret;
+	}
+
+	@Test
+	public void testEdges() {
+		BVEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
+				createEdge(4));
+
+		edges.initialize(initialEdges);
+		assertEdges(edges, 1, 2, 4);
+
+		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+		assertEdges(edges, 1, 2, 3, 4); // order matters, it's an array
+
+		edges.remove(new IntWritable(2));
+		assertEdges(edges, 1, 3, 4);
+	}
+
+	@Test
+	public void testInitialize() {
+		BVEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
+				createEdge(4));
+
+		edges.initialize(initialEdges);
+		assertEdges(edges, 1, 2, 4);
+
+		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+		assertEdges(edges, 1, 2, 3, 4);
+
+		edges.initialize();
+		assertEquals(0, edges.size());
+	}
+
+	@Test
+	public void testInitializeUnsorted() {
+		BVEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(3), createEdge(4),
+				createEdge(1));
+
+		edges.initialize(initialEdges);
+		assertEdges(edges, 1, 3, 4);
+
+		edges.add(EdgeFactory.createReusable(new IntWritable(2)));
+		assertEdges(edges, 1, 2, 3, 4);
+
+		edges.initialize();
+		assertEquals(0, edges.size());
+	}
+
+	@Test
+	public void testMutateEdges() {
+		BVEdges edges = getEdges();
+
+		edges.initialize();
+
+		// Add 10 edges with id i, for i = 0..9
+		for (int i = 0; i < 10; ++i) {
+			edges.add(createEdge(i));
+		}
+
+		// Remove edges with even id
+		for (int i = 0; i < 10; i += 2) {
+			edges.remove(new IntWritable(i));
+		}
+
+		// We should now have 5 edges
+		assertEquals(5, edges.size());
+		// The edge ids should be all odd
+		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+			assertEquals(1, edge.getTargetVertexId().get() % 2);
+		}
+	}
+
+	@Test
+	public void testSerialization() throws IOException {
+		BVEdges edges = getEdges();
+
+		edges.initialize();
+
+		// Add 10 edges with id i, for i = 0..9
+		for (int i = 0; i < 10; ++i) {
+			edges.add(createEdge(i));
+		}
+
+		// Remove edges with even id
+		for (int i = 0; i < 10; i += 2) {
+			edges.remove(new IntWritable(i));
+		}
+
+		// We should now have 5 edges
+		assertEdges(edges, 1, 3, 5, 7, 9); // id order matter because of the implementation
+
+		ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
+		DataOutputStream tempBuffer = new DataOutputStream(arrayStream);
+
+		edges.write(tempBuffer);
+		tempBuffer.close();
+
+		byte[] binary = arrayStream.toByteArray();
+
+		assertTrue("Serialized version should not be empty ", binary.length > 0);
+
+		edges = getEdges();
+		edges.readFields(new DataInputStream(new ByteArrayInputStream(binary)));
+
+		assertEquals(5, edges.size());
+
+		int[] ids = new int[] { 1, 3, 5, 7, 9 };
+		int index = 0;
+
+		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+			assertEquals(ids[index], edge.getTargetVertexId().get());
+			index++;
+		}
+		assertEquals(ids.length, index);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testParallelEdges() {
+		BVEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(2), createEdge(2),
+				createEdge(2));
+
+		edges.initialize(initialEdges);
+	}
+
+	@Test
+	public void testEdgeValues() {
+		BVEdges edges = getEdges();
+		Set<Integer> testValues = new HashSet<Integer>();
+		testValues.add(0);
+		testValues.add(Integer.MAX_VALUE / 2);
+		testValues.add(Integer.MAX_VALUE);
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = new ArrayList<Edge<IntWritable, NullWritable>>();
+		for (Integer id : testValues) {
+			initialEdges.add(createEdge(id));
+		}
+
+		edges.initialize(initialEdges);
+
+		Iterator<Edge<IntWritable, NullWritable>> edgeIt = edges.iterator();
+		while (edgeIt.hasNext()) {
+			int value = edgeIt.next().getTargetVertexId().get();
+			assertTrue("Unknown edge found " + value, testValues.remove(value));
+		}
+	}
+
+	@Test
+	public void testAddedSmallerValues() {
+		BVEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(100));
+
+		edges.initialize(initialEdges);
+
+		for (int i = 0; i < 16; i++) {
+			edges.add(createEdge(i));
+		}
+
+		assertEquals(17, edges.size());
+	}
+
+	@Test
+	public void testCompressedSize() throws IOException {
+		BVEdges edges = getEdges();
+
+		// Add 10 edges with id i, for i = 0..9
+		// to create one large interval
+		for (int i = 0; i < 10; ++i) {
+			edges.add(createEdge(i));
+		}
+		
+		// Add a residual edge
+		edges.add(createEdge(23));
+		
+		// Add 10 edges with id i, for i = 50..59
+		// to create a second large interval
+		for (int i = 50; i < 60; ++i) {
+			edges.add(createEdge(i));
+		}
+		
+		assertEquals(21, edges.size());
+		
+		DataOutput dataOutput = Mockito.mock(DataOutput.class);
+		edges.write(dataOutput);
+
+		// size of intervalResiduals byte array should be equal to 12
+		ArgumentCaptor<byte[]> intervalsAndResidualsCaptop = ArgumentCaptor.forClass(byte[].class);
+		Mockito.verify(dataOutput).write(intervalsAndResidualsCaptop.capture(), Mockito.anyInt(), Mockito.anyInt());
+		assertEquals(12, intervalsAndResidualsCaptop.getValue().length);
+	}
+	
+}

--- a/giraph-core/src/test/java/org/apache/giraph/edge/BVEdgesEdgesTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/edge/BVEdgesEdgesTest.java
@@ -53,224 +53,230 @@ import static org.junit.Assert.assertTrue;
  * removals are expensive. Parallel edges are not allowed.
  */
 public class BVEdgesEdgesTest {
-	private static Edge<IntWritable, NullWritable> createEdge(int id) {
-		return EdgeFactory.create(new IntWritable(id));
-	}
+  private static Edge<IntWritable, NullWritable> createEdge(int id) {
+    return EdgeFactory.create(new IntWritable(id));
+  }
 
-	private static void assertEdges(BVEdges edges, int... expected) {
-		int index = 0;
-		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
-			Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
-			index++;
-		}
-		Assert.assertEquals(expected.length, index);
-	}
+  private static void assertEdges(BVEdges edges, int... expected) {
+    int index = 0;
+    for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+      Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
+      index++;
+    }
+    Assert.assertEquals(expected.length, index);
+  }
 
-	private BVEdges getEdges() {
-		GiraphConfiguration gc = new GiraphConfiguration();
-		GiraphConstants.VERTEX_ID_CLASS.set(gc, IntWritable.class);
-		GiraphConstants.EDGE_VALUE_CLASS.set(gc, NullWritable.class);
-		ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable> conf = new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
-				gc);
-		BVEdges ret = new BVEdges();
-		ret.setConf(new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(conf));
-		return ret;
-	}
+  private BVEdges getEdges() {
+    GiraphConfiguration gc = new GiraphConfiguration();
+    GiraphConstants.VERTEX_ID_CLASS.set(gc, IntWritable.class);
+    GiraphConstants.EDGE_VALUE_CLASS.set(gc, NullWritable.class);
+    ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable> conf = new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
+        gc);
+    BVEdges ret = new BVEdges();
+    ret.setConf(
+        new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
+            conf));
+    return ret;
+  }
 
-	@Test
-	public void testEdges() {
-		BVEdges edges = getEdges();
+  @Test
+  public void testEdges() {
+    BVEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
-				createEdge(4));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(1), createEdge(2), createEdge(4));
 
-		edges.initialize(initialEdges);
-		assertEdges(edges, 1, 2, 4);
+    edges.initialize(initialEdges);
+    assertEdges(edges, 1, 2, 4);
 
-		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
-		assertEdges(edges, 1, 2, 3, 4); // order matters, it's an array
+    edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+    assertEdges(edges, 1, 2, 3, 4); // order matters, it's an array
 
-		edges.remove(new IntWritable(2));
-		assertEdges(edges, 1, 3, 4);
-	}
+    edges.remove(new IntWritable(2));
+    assertEdges(edges, 1, 3, 4);
+  }
 
-	@Test
-	public void testInitialize() {
-		BVEdges edges = getEdges();
+  @Test
+  public void testInitialize() {
+    BVEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
-				createEdge(4));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(1), createEdge(2), createEdge(4));
 
-		edges.initialize(initialEdges);
-		assertEdges(edges, 1, 2, 4);
+    edges.initialize(initialEdges);
+    assertEdges(edges, 1, 2, 4);
 
-		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
-		assertEdges(edges, 1, 2, 3, 4);
+    edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+    assertEdges(edges, 1, 2, 3, 4);
 
-		edges.initialize();
-		assertEquals(0, edges.size());
-	}
+    edges.initialize();
+    assertEquals(0, edges.size());
+  }
 
-	@Test
-	public void testInitializeUnsorted() {
-		BVEdges edges = getEdges();
+  @Test
+  public void testInitializeUnsorted() {
+    BVEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(3), createEdge(4),
-				createEdge(1));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(3), createEdge(4), createEdge(1));
 
-		edges.initialize(initialEdges);
-		assertEdges(edges, 1, 3, 4);
+    edges.initialize(initialEdges);
+    assertEdges(edges, 1, 3, 4);
 
-		edges.add(EdgeFactory.createReusable(new IntWritable(2)));
-		assertEdges(edges, 1, 2, 3, 4);
+    edges.add(EdgeFactory.createReusable(new IntWritable(2)));
+    assertEdges(edges, 1, 2, 3, 4);
 
-		edges.initialize();
-		assertEquals(0, edges.size());
-	}
+    edges.initialize();
+    assertEquals(0, edges.size());
+  }
 
-	@Test
-	public void testMutateEdges() {
-		BVEdges edges = getEdges();
+  @Test
+  public void testMutateEdges() {
+    BVEdges edges = getEdges();
 
-		edges.initialize();
+    edges.initialize();
 
-		// Add 10 edges with id i, for i = 0..9
-		for (int i = 0; i < 10; ++i) {
-			edges.add(createEdge(i));
-		}
+    // Add 10 edges with id i, for i = 0..9
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
 
-		// Remove edges with even id
-		for (int i = 0; i < 10; i += 2) {
-			edges.remove(new IntWritable(i));
-		}
+    // Remove edges with even id
+    for (int i = 0; i < 10; i += 2) {
+      edges.remove(new IntWritable(i));
+    }
 
-		// We should now have 5 edges
-		assertEquals(5, edges.size());
-		// The edge ids should be all odd
-		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
-			assertEquals(1, edge.getTargetVertexId().get() % 2);
-		}
-	}
+    // We should now have 5 edges
+    assertEquals(5, edges.size());
+    // The edge ids should be all odd
+    for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+      assertEquals(1, edge.getTargetVertexId().get() % 2);
+    }
+  }
 
-	@Test
-	public void testSerialization() throws IOException {
-		BVEdges edges = getEdges();
+  @Test
+  public void testSerialization() throws IOException {
+    BVEdges edges = getEdges();
 
-		edges.initialize();
+    edges.initialize();
 
-		// Add 10 edges with id i, for i = 0..9
-		for (int i = 0; i < 10; ++i) {
-			edges.add(createEdge(i));
-		}
+    // Add 10 edges with id i, for i = 0..9
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
 
-		// Remove edges with even id
-		for (int i = 0; i < 10; i += 2) {
-			edges.remove(new IntWritable(i));
-		}
+    // Remove edges with even id
+    for (int i = 0; i < 10; i += 2) {
+      edges.remove(new IntWritable(i));
+    }
 
-		// We should now have 5 edges
-		assertEdges(edges, 1, 3, 5, 7, 9); // id order matter because of the implementation
+    // We should now have 5 edges
+    assertEdges(edges, 1, 3, 5, 7, 9); // id order matter because of the
+                                       // implementation
 
-		ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
-		DataOutputStream tempBuffer = new DataOutputStream(arrayStream);
+    ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
+    DataOutputStream tempBuffer = new DataOutputStream(arrayStream);
 
-		edges.write(tempBuffer);
-		tempBuffer.close();
+    edges.write(tempBuffer);
+    tempBuffer.close();
 
-		byte[] binary = arrayStream.toByteArray();
+    byte[] binary = arrayStream.toByteArray();
 
-		assertTrue("Serialized version should not be empty ", binary.length > 0);
+    assertTrue("Serialized version should not be empty ", binary.length > 0);
 
-		edges = getEdges();
-		edges.readFields(new DataInputStream(new ByteArrayInputStream(binary)));
+    edges = getEdges();
+    edges.readFields(new DataInputStream(new ByteArrayInputStream(binary)));
 
-		assertEquals(5, edges.size());
+    assertEquals(5, edges.size());
 
-		int[] ids = new int[] { 1, 3, 5, 7, 9 };
-		int index = 0;
+    int[] ids = new int[] { 1, 3, 5, 7, 9 };
+    int index = 0;
 
-		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
-			assertEquals(ids[index], edge.getTargetVertexId().get());
-			index++;
-		}
-		assertEquals(ids.length, index);
-	}
+    for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+      assertEquals(ids[index], edge.getTargetVertexId().get());
+      index++;
+    }
+    assertEquals(ids.length, index);
+  }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testParallelEdges() {
-		BVEdges edges = getEdges();
+  @Test(expected = IllegalArgumentException.class)
+  public void testParallelEdges() {
+    BVEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(2), createEdge(2),
-				createEdge(2));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(2), createEdge(2), createEdge(2));
 
-		edges.initialize(initialEdges);
-	}
+    edges.initialize(initialEdges);
+  }
 
-	@Test
-	public void testEdgeValues() {
-		BVEdges edges = getEdges();
-		Set<Integer> testValues = new HashSet<Integer>();
-		testValues.add(0);
-		testValues.add(Integer.MAX_VALUE / 2);
-		testValues.add(Integer.MAX_VALUE);
+  @Test
+  public void testEdgeValues() {
+    BVEdges edges = getEdges();
+    Set<Integer> testValues = new HashSet<Integer>();
+    testValues.add(0);
+    testValues.add(Integer.MAX_VALUE / 2);
+    testValues.add(Integer.MAX_VALUE);
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = new ArrayList<Edge<IntWritable, NullWritable>>();
-		for (Integer id : testValues) {
-			initialEdges.add(createEdge(id));
-		}
+    List<Edge<IntWritable, NullWritable>> initialEdges = new ArrayList<Edge<IntWritable, NullWritable>>();
+    for (Integer id : testValues) {
+      initialEdges.add(createEdge(id));
+    }
 
-		edges.initialize(initialEdges);
+    edges.initialize(initialEdges);
 
-		Iterator<Edge<IntWritable, NullWritable>> edgeIt = edges.iterator();
-		while (edgeIt.hasNext()) {
-			int value = edgeIt.next().getTargetVertexId().get();
-			assertTrue("Unknown edge found " + value, testValues.remove(value));
-		}
-	}
+    Iterator<Edge<IntWritable, NullWritable>> edgeIt = edges.iterator();
+    while (edgeIt.hasNext()) {
+      int value = edgeIt.next().getTargetVertexId().get();
+      assertTrue("Unknown edge found " + value, testValues.remove(value));
+    }
+  }
 
-	@Test
-	public void testAddedSmallerValues() {
-		BVEdges edges = getEdges();
+  @Test
+  public void testAddedSmallerValues() {
+    BVEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(100));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(100));
 
-		edges.initialize(initialEdges);
+    edges.initialize(initialEdges);
 
-		for (int i = 0; i < 16; i++) {
-			edges.add(createEdge(i));
-		}
+    for (int i = 0; i < 16; i++) {
+      edges.add(createEdge(i));
+    }
 
-		assertEquals(17, edges.size());
-	}
+    assertEquals(17, edges.size());
+  }
 
-	@Test
-	public void testCompressedSize() throws IOException {
-		BVEdges edges = getEdges();
+  @Test
+  public void testCompressedSize() throws IOException {
+    BVEdges edges = getEdges();
 
-		// Add 10 edges with id i, for i = 0..9
-		// to create one large interval
-		for (int i = 0; i < 10; ++i) {
-			edges.add(createEdge(i));
-		}
-		
-		// Add a residual edge
-		edges.add(createEdge(23));
-		
-		// Add 10 edges with id i, for i = 50..59
-		// to create a second large interval
-		for (int i = 50; i < 60; ++i) {
-			edges.add(createEdge(i));
-		}
-		
-		assertEquals(21, edges.size());
-		
-		DataOutput dataOutput = Mockito.mock(DataOutput.class);
-		edges.write(dataOutput);
+    // Add 10 edges with id i, for i = 0..9
+    // to create one large interval
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
 
-		// size of intervalResiduals byte array should be equal to 12
-		ArgumentCaptor<byte[]> intervalsAndResidualsCaptop = ArgumentCaptor.forClass(byte[].class);
-		Mockito.verify(dataOutput).write(intervalsAndResidualsCaptop.capture(), Mockito.anyInt(), Mockito.anyInt());
-		assertEquals(12, intervalsAndResidualsCaptop.getValue().length);
-	}
-	
+    // Add a residual edge
+    edges.add(createEdge(23));
+
+    // Add 10 edges with id i, for i = 50..59
+    // to create a second large interval
+    for (int i = 50; i < 60; ++i) {
+      edges.add(createEdge(i));
+    }
+
+    assertEquals(21, edges.size());
+
+    DataOutput dataOutput = Mockito.mock(DataOutput.class);
+    edges.write(dataOutput);
+
+    // size of intervalResiduals byte array should be equal to 12
+    ArgumentCaptor<byte[]> intervalsAndResidualsCaptop = ArgumentCaptor
+        .forClass(byte[].class);
+    Mockito.verify(dataOutput).write(intervalsAndResidualsCaptop.capture(),
+        Mockito.anyInt(), Mockito.anyInt());
+    assertEquals(12, intervalsAndResidualsCaptop.getValue().length);
+  }
+
 }

--- a/giraph-core/src/test/java/org/apache/giraph/edge/IndexedBitArrayEdgesTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/edge/IndexedBitArrayEdgesTest.java
@@ -259,7 +259,7 @@ public class IndexedBitArrayEdgesTest {
 		edges.write(dataOutput);
 
 		// size of serializedEdges byte array should be equal to 15:
-		// 5 (bucket 0: 0-7) + 5 (bucket 1: 8-10) + 5 (bucket 3: 23)
+		// 5 (bucket 0: 0-7) + 5 (bucket 1: 8-10) + 5 (bucket 2: 23)
 		ArgumentCaptor<byte[]> serializedEdgesCaptop = ArgumentCaptor.forClass(byte[].class);
 		Mockito.verify(dataOutput).write(serializedEdgesCaptop.capture(), Mockito.anyInt(), Mockito.anyInt());
 		assertEquals(15, serializedEdgesCaptop.getValue().length);

--- a/giraph-core/src/test/java/org/apache/giraph/edge/IndexedBitArrayEdgesTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/edge/IndexedBitArrayEdgesTest.java
@@ -45,223 +45,227 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class IndexedBitArrayEdgesTest {
-	private static Edge<IntWritable, NullWritable> createEdge(int id) {
-		return EdgeFactory.create(new IntWritable(id));
-	}
+  private static Edge<IntWritable, NullWritable> createEdge(int id) {
+    return EdgeFactory.create(new IntWritable(id));
+  }
 
-	private static void assertEdges(IndexedBitArrayEdges edges, int... expected) {
-		int index = 0;
-		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
-			Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
-			index++;
-		}
-		Assert.assertEquals(expected.length, index);
-	}
+  private static void assertEdges(IndexedBitArrayEdges edges, int... expected) {
+    int index = 0;
+    for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+      Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
+      index++;
+    }
+    Assert.assertEquals(expected.length, index);
+  }
 
-	private IndexedBitArrayEdges getEdges() {
-		GiraphConfiguration gc = new GiraphConfiguration();
-		GiraphConstants.VERTEX_ID_CLASS.set(gc, IntWritable.class);
-		GiraphConstants.EDGE_VALUE_CLASS.set(gc, NullWritable.class);
-		ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable> conf = new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
-				gc);
-		IndexedBitArrayEdges ret = new IndexedBitArrayEdges();
-		ret.setConf(new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(conf));
-		return ret;
-	}
+  private IndexedBitArrayEdges getEdges() {
+    GiraphConfiguration gc = new GiraphConfiguration();
+    GiraphConstants.VERTEX_ID_CLASS.set(gc, IntWritable.class);
+    GiraphConstants.EDGE_VALUE_CLASS.set(gc, NullWritable.class);
+    ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable> conf = new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
+        gc);
+    IndexedBitArrayEdges ret = new IndexedBitArrayEdges();
+    ret.setConf(
+        new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
+            conf));
+    return ret;
+  }
 
-	@Test
-	public void testEdges() {
-		IndexedBitArrayEdges edges = getEdges();
+  @Test
+  public void testEdges() {
+    IndexedBitArrayEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
-				createEdge(4));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(1), createEdge(2), createEdge(4));
 
-		edges.initialize(initialEdges);
-		assertEdges(edges, 1, 2, 4);
+    edges.initialize(initialEdges);
+    assertEdges(edges, 1, 2, 4);
 
-		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
-		assertEdges(edges, 1, 2, 3, 4); // order matters, it's an array
+    edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+    assertEdges(edges, 1, 2, 3, 4); // order matters, it's an array
 
-		edges.remove(new IntWritable(2));
-		assertEdges(edges, 1, 3, 4);
-	}
+    edges.remove(new IntWritable(2));
+    assertEdges(edges, 1, 3, 4);
+  }
 
-	@Test
-	public void testInitialize() {
-		IndexedBitArrayEdges edges = getEdges();
+  @Test
+  public void testInitialize() {
+    IndexedBitArrayEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
-				createEdge(4));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(1), createEdge(2), createEdge(4));
 
-		edges.initialize(initialEdges);
-		assertEdges(edges, 1, 2, 4);
+    edges.initialize(initialEdges);
+    assertEdges(edges, 1, 2, 4);
 
-		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
-		assertEdges(edges, 1, 2, 3, 4);
+    edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+    assertEdges(edges, 1, 2, 3, 4);
 
-		edges.initialize();
-		assertEquals(0, edges.size());
-	}
+    edges.initialize();
+    assertEquals(0, edges.size());
+  }
 
-	@Test
-	public void testInitializeUnsorted() {
-		IndexedBitArrayEdges edges = getEdges();
+  @Test
+  public void testInitializeUnsorted() {
+    IndexedBitArrayEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(3), createEdge(4),
-				createEdge(1));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(3), createEdge(4), createEdge(1));
 
-		edges.initialize(initialEdges);
-		assertEdges(edges, 1, 3, 4);
+    edges.initialize(initialEdges);
+    assertEdges(edges, 1, 3, 4);
 
-		edges.add(EdgeFactory.createReusable(new IntWritable(2)));
-		
-		assertEdges(edges, 1, 2, 3, 4);
+    edges.add(EdgeFactory.createReusable(new IntWritable(2)));
 
-		edges.initialize();
-		assertEquals(0, edges.size());
-	}
+    assertEdges(edges, 1, 2, 3, 4);
 
-	@Test
-	public void testMutateEdges() {
-		IndexedBitArrayEdges edges = getEdges();
+    edges.initialize();
+    assertEquals(0, edges.size());
+  }
 
-		edges.initialize();
+  @Test
+  public void testMutateEdges() {
+    IndexedBitArrayEdges edges = getEdges();
 
-		// Add 10 edges with id i, for i = 0..9
-		for (int i = 0; i < 10; ++i) {
-			edges.add(createEdge(i));
-		}
+    edges.initialize();
 
-		// Remove edges with even id
-		for (int i = 0; i < 10; i += 2) {
-			edges.remove(new IntWritable(i));
-		}
+    // Add 10 edges with id i, for i = 0..9
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
 
-		// We should now have 5 edges
-		assertEquals(5, edges.size());
-		// The edge ids should be all odd
-		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
-			assertEquals(1, edge.getTargetVertexId().get() % 2);
-		}
-	}
+    // Remove edges with even id
+    for (int i = 0; i < 10; i += 2) {
+      edges.remove(new IntWritable(i));
+    }
 
-	@Test
-	public void testSerialization() throws IOException {
-		IndexedBitArrayEdges edges = getEdges();
+    // We should now have 5 edges
+    assertEquals(5, edges.size());
+    // The edge ids should be all odd
+    for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+      assertEquals(1, edge.getTargetVertexId().get() % 2);
+    }
+  }
 
-		edges.initialize();
+  @Test
+  public void testSerialization() throws IOException {
+    IndexedBitArrayEdges edges = getEdges();
 
-		// Add 10 edges with id i, for i = 0..9
-		for (int i = 0; i < 10; ++i) {
-			edges.add(createEdge(i));
-		}
+    edges.initialize();
 
-		// Remove edges with even id
-		for (int i = 0; i < 10; i += 2) {
-			edges.remove(new IntWritable(i));
-		}
+    // Add 10 edges with id i, for i = 0..9
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
 
-		// We should now have 5 edges
-		assertEdges(edges, 1, 3, 5, 7, 9); // id order matter because of the implementation
+    // Remove edges with even id
+    for (int i = 0; i < 10; i += 2) {
+      edges.remove(new IntWritable(i));
+    }
 
-		ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
-		DataOutputStream tempBuffer = new DataOutputStream(arrayStream);
+    // We should now have 5 edges
+    assertEdges(edges, 1, 3, 5, 7, 9); // id order matter because of the
+                                       // implementation
 
-		edges.write(tempBuffer);
-		tempBuffer.close();
+    ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
+    DataOutputStream tempBuffer = new DataOutputStream(arrayStream);
 
-		byte[] binary = arrayStream.toByteArray();
+    edges.write(tempBuffer);
+    tempBuffer.close();
 
-		assertTrue("Serialized version should not be empty ", binary.length > 0);
+    byte[] binary = arrayStream.toByteArray();
 
-		edges = getEdges();
-		edges.readFields(new DataInputStream(new ByteArrayInputStream(binary)));
+    assertTrue("Serialized version should not be empty ", binary.length > 0);
 
-		assertEquals(5, edges.size());
+    edges = getEdges();
+    edges.readFields(new DataInputStream(new ByteArrayInputStream(binary)));
 
-		int[] ids = new int[] { 1, 3, 5, 7, 9 };
-		int index = 0;
+    assertEquals(5, edges.size());
 
-		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
-			assertEquals(ids[index], edge.getTargetVertexId().get());
-			index++;
-		}
-		assertEquals(ids.length, index);
-	}
+    int[] ids = new int[] { 1, 3, 5, 7, 9 };
+    int index = 0;
 
-	@Test
-	public void testParallelEdges() {
-		IndexedBitArrayEdges edges = getEdges();
+    for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+      assertEquals(ids[index], edge.getTargetVertexId().get());
+      index++;
+    }
+    assertEquals(ids.length, index);
+  }
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(2), createEdge(2),
-				createEdge(2));
+  @Test(expected = IllegalArgumentException.class)
+  public void testParallelEdges() {
+    IndexedBitArrayEdges edges = getEdges();
 
-		edges.initialize(initialEdges);
-		
-		assertEquals(1, edges.size());
-	}
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(2), createEdge(2), createEdge(2));
 
-	@Test
-	public void testEdgeValues() {
-		IndexedBitArrayEdges edges = getEdges();
-		Set<Integer> testValues = new HashSet<Integer>();
-		testValues.add(0);
-		testValues.add(Integer.MAX_VALUE / 2);
-		testValues.add(Integer.MAX_VALUE);
+    edges.initialize(initialEdges);
+  }
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = new ArrayList<Edge<IntWritable, NullWritable>>();
-		for (Integer id : testValues) {
-			initialEdges.add(createEdge(id));
-		}
+  @Test
+  public void testEdgeValues() {
+    IndexedBitArrayEdges edges = getEdges();
+    Set<Integer> testValues = new HashSet<Integer>();
+    testValues.add(0);
+    testValues.add(Integer.MAX_VALUE / 2);
+    testValues.add(Integer.MAX_VALUE);
 
-		edges.initialize(initialEdges);
+    List<Edge<IntWritable, NullWritable>> initialEdges = new ArrayList<Edge<IntWritable, NullWritable>>();
+    for (Integer id : testValues) {
+      initialEdges.add(createEdge(id));
+    }
 
-		Iterator<Edge<IntWritable, NullWritable>> edgeIt = edges.iterator();
-		while (edgeIt.hasNext()) {
-			int value = edgeIt.next().getTargetVertexId().get();
-			assertTrue("Unknown edge found " + value, testValues.remove(value));
-		}
-	}
+    edges.initialize(initialEdges);
 
-	@Test
-	public void testAddedSmallerValues() {
-		IndexedBitArrayEdges edges = getEdges();
+    Iterator<Edge<IntWritable, NullWritable>> edgeIt = edges.iterator();
+    while (edgeIt.hasNext()) {
+      int value = edgeIt.next().getTargetVertexId().get();
+      assertTrue("Unknown edge found " + value, testValues.remove(value));
+    }
+  }
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(100));
+  @Test
+  public void testAddedSmallerValues() {
+    IndexedBitArrayEdges edges = getEdges();
 
-		edges.initialize(initialEdges);
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(100));
 
-		for (int i = 0; i < 16; i++) {
-			edges.add(createEdge(i));
-		}
+    edges.initialize(initialEdges);
 
-		assertEquals(17, edges.size());
-	}
+    for (int i = 0; i < 16; i++) {
+      edges.add(createEdge(i));
+    }
 
-	@Test
-	public void testCompressedSize() throws IOException {
-		IndexedBitArrayEdges edges = getEdges();
+    assertEquals(17, edges.size());
+  }
 
-		edges.initialize();
-		
-		// Add 10 edges with id i, for i = 0..9
-		// to create on large interval
-		for (int i = 0; i < 10; ++i) {
-			edges.add(createEdge(i));
-		}
-		
-		// Add a residual edge
-		edges.add(createEdge(23));
-		
-		assertEquals(11, edges.size());
-		
-		DataOutput dataOutput = Mockito.mock(DataOutput.class);
-		edges.write(dataOutput);
+  @Test
+  public void testCompressedSize() throws IOException {
+    IndexedBitArrayEdges edges = getEdges();
 
-		// size of serializedEdges byte array should be equal to 15:
-		// 5 (bucket 0: 0-7) + 5 (bucket 1: 8-10) + 5 (bucket 2: 23)
-		ArgumentCaptor<byte[]> serializedEdgesCaptop = ArgumentCaptor.forClass(byte[].class);
-		Mockito.verify(dataOutput).write(serializedEdgesCaptop.capture(), Mockito.anyInt(), Mockito.anyInt());
-		assertEquals(15, serializedEdgesCaptop.getValue().length);
-	}
+    edges.initialize();
+
+    // Add 10 edges with id i, for i = 0..9
+    // to create on large interval
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
+
+    // Add a residual edge
+    edges.add(createEdge(23));
+
+    assertEquals(11, edges.size());
+
+    DataOutput dataOutput = Mockito.mock(DataOutput.class);
+    edges.write(dataOutput);
+
+    // size of serializedEdges byte array should be equal to 15:
+    // 5 (bucket 0: 0-7) + 5 (bucket 1: 8-10) + 5 (bucket 2: 23)
+    ArgumentCaptor<byte[]> serializedEdgesCaptop = ArgumentCaptor
+        .forClass(byte[].class);
+    Mockito.verify(dataOutput).write(serializedEdgesCaptop.capture(),
+        Mockito.anyInt(), Mockito.anyInt());
+    assertEquals(15, serializedEdgesCaptop.getValue().length);
+  }
 }

--- a/giraph-core/src/test/java/org/apache/giraph/edge/IndexedBitArrayEdgesTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/edge/IndexedBitArrayEdgesTest.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.giraph.edge;
+
+import com.google.common.collect.Lists;
+import org.apache.giraph.conf.GiraphConfiguration;
+import org.apache.giraph.conf.GiraphConstants;
+import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class IndexedBitArrayEdgesTest {
+	private static Edge<IntWritable, NullWritable> createEdge(int id) {
+		return EdgeFactory.create(new IntWritable(id));
+	}
+
+	private static void assertEdges(IndexedBitArrayEdges edges, int... expected) {
+		int index = 0;
+		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+			Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
+			index++;
+		}
+		Assert.assertEquals(expected.length, index);
+	}
+
+	private IndexedBitArrayEdges getEdges() {
+		GiraphConfiguration gc = new GiraphConfiguration();
+		GiraphConstants.VERTEX_ID_CLASS.set(gc, IntWritable.class);
+		GiraphConstants.EDGE_VALUE_CLASS.set(gc, NullWritable.class);
+		ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable> conf = new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
+				gc);
+		IndexedBitArrayEdges ret = new IndexedBitArrayEdges();
+		ret.setConf(new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(conf));
+		return ret;
+	}
+
+	@Test
+	public void testEdges() {
+		IndexedBitArrayEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
+				createEdge(4));
+
+		edges.initialize(initialEdges);
+		assertEdges(edges, 1, 2, 4);
+
+		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+		assertEdges(edges, 1, 2, 3, 4); // order matters, it's an array
+
+		edges.remove(new IntWritable(2));
+		assertEdges(edges, 1, 3, 4);
+	}
+
+	@Test
+	public void testInitialize() {
+		IndexedBitArrayEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
+				createEdge(4));
+
+		edges.initialize(initialEdges);
+		assertEdges(edges, 1, 2, 4);
+
+		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+		assertEdges(edges, 1, 2, 3, 4);
+
+		edges.initialize();
+		assertEquals(0, edges.size());
+	}
+
+	@Test
+	public void testInitializeUnsorted() {
+		IndexedBitArrayEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(3), createEdge(4),
+				createEdge(1));
+
+		edges.initialize(initialEdges);
+		assertEdges(edges, 1, 3, 4);
+
+		edges.add(EdgeFactory.createReusable(new IntWritable(2)));
+		
+		assertEdges(edges, 1, 2, 3, 4);
+
+		edges.initialize();
+		assertEquals(0, edges.size());
+	}
+
+	@Test
+	public void testMutateEdges() {
+		IndexedBitArrayEdges edges = getEdges();
+
+		edges.initialize();
+
+		// Add 10 edges with id i, for i = 0..9
+		for (int i = 0; i < 10; ++i) {
+			edges.add(createEdge(i));
+		}
+
+		// Remove edges with even id
+		for (int i = 0; i < 10; i += 2) {
+			edges.remove(new IntWritable(i));
+		}
+
+		// We should now have 5 edges
+		assertEquals(5, edges.size());
+		// The edge ids should be all odd
+		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+			assertEquals(1, edge.getTargetVertexId().get() % 2);
+		}
+	}
+
+	@Test
+	public void testSerialization() throws IOException {
+		IndexedBitArrayEdges edges = getEdges();
+
+		edges.initialize();
+
+		// Add 10 edges with id i, for i = 0..9
+		for (int i = 0; i < 10; ++i) {
+			edges.add(createEdge(i));
+		}
+
+		// Remove edges with even id
+		for (int i = 0; i < 10; i += 2) {
+			edges.remove(new IntWritable(i));
+		}
+
+		// We should now have 5 edges
+		assertEdges(edges, 1, 3, 5, 7, 9); // id order matter because of the implementation
+
+		ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
+		DataOutputStream tempBuffer = new DataOutputStream(arrayStream);
+
+		edges.write(tempBuffer);
+		tempBuffer.close();
+
+		byte[] binary = arrayStream.toByteArray();
+
+		assertTrue("Serialized version should not be empty ", binary.length > 0);
+
+		edges = getEdges();
+		edges.readFields(new DataInputStream(new ByteArrayInputStream(binary)));
+
+		assertEquals(5, edges.size());
+
+		int[] ids = new int[] { 1, 3, 5, 7, 9 };
+		int index = 0;
+
+		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+			assertEquals(ids[index], edge.getTargetVertexId().get());
+			index++;
+		}
+		assertEquals(ids.length, index);
+	}
+
+	@Test
+	public void testParallelEdges() {
+		IndexedBitArrayEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(2), createEdge(2),
+				createEdge(2));
+
+		edges.initialize(initialEdges);
+		
+		assertEquals(1, edges.size());
+	}
+
+	@Test
+	public void testEdgeValues() {
+		IndexedBitArrayEdges edges = getEdges();
+		Set<Integer> testValues = new HashSet<Integer>();
+		testValues.add(0);
+		testValues.add(Integer.MAX_VALUE / 2);
+		testValues.add(Integer.MAX_VALUE);
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = new ArrayList<Edge<IntWritable, NullWritable>>();
+		for (Integer id : testValues) {
+			initialEdges.add(createEdge(id));
+		}
+
+		edges.initialize(initialEdges);
+
+		Iterator<Edge<IntWritable, NullWritable>> edgeIt = edges.iterator();
+		while (edgeIt.hasNext()) {
+			int value = edgeIt.next().getTargetVertexId().get();
+			assertTrue("Unknown edge found " + value, testValues.remove(value));
+		}
+	}
+
+	@Test
+	public void testAddedSmallerValues() {
+		IndexedBitArrayEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(100));
+
+		edges.initialize(initialEdges);
+
+		for (int i = 0; i < 16; i++) {
+			edges.add(createEdge(i));
+		}
+
+		assertEquals(17, edges.size());
+	}
+
+	@Test
+	public void testCompressedSize() throws IOException {
+		IndexedBitArrayEdges edges = getEdges();
+
+		edges.initialize();
+		
+		// Add 10 edges with id i, for i = 0..9
+		// to create on large interval
+		for (int i = 0; i < 10; ++i) {
+			edges.add(createEdge(i));
+		}
+		
+		// Add a residual edge
+		edges.add(createEdge(23));
+		
+		assertEquals(11, edges.size());
+		
+		DataOutput dataOutput = Mockito.mock(DataOutput.class);
+		edges.write(dataOutput);
+
+		// size of serializedEdges byte array should be equal to 15:
+		// 5 (bucket 0: 0-7) + 5 (bucket 1: 8-10) + 5 (bucket 3: 23)
+		ArgumentCaptor<byte[]> serializedEdgesCaptop = ArgumentCaptor.forClass(byte[].class);
+		Mockito.verify(dataOutput).write(serializedEdgesCaptop.capture(), Mockito.anyInt(), Mockito.anyInt());
+		assertEquals(15, serializedEdgesCaptop.getValue().length);
+	}
+}

--- a/giraph-core/src/test/java/org/apache/giraph/edge/IntervalResidualEdgesTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/edge/IntervalResidualEdgesTest.java
@@ -45,218 +45,227 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class IntervalResidualEdgesTest {
-	private static Edge<IntWritable, NullWritable> createEdge(int id) {
-		return EdgeFactory.create(new IntWritable(id));
-	}
+  private static Edge<IntWritable, NullWritable> createEdge(int id) {
+    return EdgeFactory.create(new IntWritable(id));
+  }
 
-	private static void assertEdges(IntervalResidualEdges edges, int... expected) {
-		int index = 0;
-		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
-			Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
-			index++;
-		}
-		Assert.assertEquals(expected.length, index);
-	}
+  private static void assertEdges(IntervalResidualEdges edges,
+      int... expected) {
+    int index = 0;
+    for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+      Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
+      index++;
+    }
+    Assert.assertEquals(expected.length, index);
+  }
 
-	private IntervalResidualEdges getEdges() {
-		GiraphConfiguration gc = new GiraphConfiguration();
-		GiraphConstants.VERTEX_ID_CLASS.set(gc, IntWritable.class);
-		GiraphConstants.EDGE_VALUE_CLASS.set(gc, NullWritable.class);
-		ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable> conf = new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
-				gc);
-		IntervalResidualEdges ret = new IntervalResidualEdges();
-		ret.setConf(new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(conf));
-		return ret;
-	}
+  private IntervalResidualEdges getEdges() {
+    GiraphConfiguration gc = new GiraphConfiguration();
+    GiraphConstants.VERTEX_ID_CLASS.set(gc, IntWritable.class);
+    GiraphConstants.EDGE_VALUE_CLASS.set(gc, NullWritable.class);
+    ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable> conf = new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
+        gc);
+    IntervalResidualEdges ret = new IntervalResidualEdges();
+    ret.setConf(
+        new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
+            conf));
+    return ret;
+  }
 
-	@Test
-	public void testEdges() {
-		IntervalResidualEdges edges = getEdges();
+  @Test
+  public void testEdges() {
+    IntervalResidualEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
-				createEdge(4));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(1), createEdge(2), createEdge(4));
 
-		edges.initialize(initialEdges);
-		assertEdges(edges, 1, 2, 4);
+    edges.initialize(initialEdges);
+    assertEdges(edges, 1, 2, 4);
 
-		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
-		assertEdges(edges, 1, 2, 3, 4); // order matters, it's an array
+    edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+    assertEdges(edges, 1, 2, 3, 4); // order matters, it's an array
 
-		edges.remove(new IntWritable(2));
-		assertEdges(edges, 3, 4, 1);
-	}
+    edges.remove(new IntWritable(2));
+    assertEdges(edges, 3, 4, 1);
+  }
 
-	@Test
-	public void testInitialize() {
-		IntervalResidualEdges edges = getEdges();
+  @Test
+  public void testInitialize() {
+    IntervalResidualEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
-				createEdge(4));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(1), createEdge(2), createEdge(4));
 
-		edges.initialize(initialEdges);
-		assertEdges(edges, 1, 2, 4);
+    edges.initialize(initialEdges);
+    assertEdges(edges, 1, 2, 4);
 
-		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
-		assertEdges(edges, 1, 2, 3, 4);
+    edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+    assertEdges(edges, 1, 2, 3, 4);
 
-		edges.initialize();
-		assertEquals(0, edges.size());
-	}
+    edges.initialize();
+    assertEquals(0, edges.size());
+  }
 
-	@Test
-	public void testInitializeUnsorted() {
-		IntervalResidualEdges edges = getEdges();
+  @Test
+  public void testInitializeUnsorted() {
+    IntervalResidualEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(3), createEdge(4),
-				createEdge(1));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(3), createEdge(4), createEdge(1));
 
-		edges.initialize(initialEdges);
-		assertEdges(edges, 3, 4, 1);
+    edges.initialize(initialEdges);
+    assertEdges(edges, 3, 4, 1);
 
-		edges.add(EdgeFactory.createReusable(new IntWritable(2)));
-		assertEdges(edges, 1, 2, 3, 4);
+    edges.add(EdgeFactory.createReusable(new IntWritable(2)));
+    assertEdges(edges, 1, 2, 3, 4);
 
-		edges.initialize();
-		assertEquals(0, edges.size());
-	}
+    edges.initialize();
+    assertEquals(0, edges.size());
+  }
 
-	@Test
-	public void testMutateEdges() {
-		IntervalResidualEdges edges = getEdges();
+  @Test
+  public void testMutateEdges() {
+    IntervalResidualEdges edges = getEdges();
 
-		edges.initialize();
+    edges.initialize();
 
-		// Add 10 edges with id i, for i = 0..9
-		for (int i = 0; i < 10; ++i) {
-			edges.add(createEdge(i));
-		}
+    // Add 10 edges with id i, for i = 0..9
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
 
-		// Remove edges with even id
-		for (int i = 0; i < 10; i += 2) {
-			edges.remove(new IntWritable(i));
-		}
+    // Remove edges with even id
+    for (int i = 0; i < 10; i += 2) {
+      edges.remove(new IntWritable(i));
+    }
 
-		// We should now have 5 edges
-		assertEquals(5, edges.size());
-		// The edge ids should be all odd
-		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
-			assertEquals(1, edge.getTargetVertexId().get() % 2);
-		}
-	}
+    // We should now have 5 edges
+    assertEquals(5, edges.size());
+    // The edge ids should be all odd
+    for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+      assertEquals(1, edge.getTargetVertexId().get() % 2);
+    }
+  }
 
-	@Test
-	public void testSerialization() throws IOException {
-		IntervalResidualEdges edges = getEdges();
+  @Test
+  public void testSerialization() throws IOException {
+    IntervalResidualEdges edges = getEdges();
 
-		edges.initialize();
+    edges.initialize();
 
-		// Add 10 edges with id i, for i = 0..9
-		for (int i = 0; i < 10; ++i) {
-			edges.add(createEdge(i));
-		}
+    // Add 10 edges with id i, for i = 0..9
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
 
-		// Remove edges with even id
-		for (int i = 0; i < 10; i += 2) {
-			edges.remove(new IntWritable(i));
-		}
+    // Remove edges with even id
+    for (int i = 0; i < 10; i += 2) {
+      edges.remove(new IntWritable(i));
+    }
 
-		// We should now have 5 edges
-		assertEdges(edges, 1, 3, 5, 7, 9); // id order matter because of the implementation
+    // We should now have 5 edges
+    assertEdges(edges, 1, 3, 5, 7, 9); // id order matter because of the
+                                       // implementation
 
-		ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
-		DataOutputStream tempBuffer = new DataOutputStream(arrayStream);
+    ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
+    DataOutputStream tempBuffer = new DataOutputStream(arrayStream);
 
-		edges.write(tempBuffer);
-		tempBuffer.close();
+    edges.write(tempBuffer);
+    tempBuffer.close();
 
-		byte[] binary = arrayStream.toByteArray();
+    byte[] binary = arrayStream.toByteArray();
 
-		assertTrue("Serialized version should not be empty ", binary.length > 0);
+    assertTrue("Serialized version should not be empty ", binary.length > 0);
 
-		edges = getEdges();
-		edges.readFields(new DataInputStream(new ByteArrayInputStream(binary)));
+    edges = getEdges();
+    edges.readFields(new DataInputStream(new ByteArrayInputStream(binary)));
 
-		assertEquals(5, edges.size());
+    assertEquals(5, edges.size());
 
-		int[] ids = new int[] { 1, 3, 5, 7, 9 };
-		int index = 0;
+    int[] ids = new int[] { 1, 3, 5, 7, 9 };
+    int index = 0;
 
-		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
-			assertEquals(ids[index], edge.getTargetVertexId().get());
-			index++;
-		}
-		assertEquals(ids.length, index);
-	}
+    for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+      assertEquals(ids[index], edge.getTargetVertexId().get());
+      index++;
+    }
+    assertEquals(ids.length, index);
+  }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testParallelEdges() {
-		IntervalResidualEdges edges = getEdges();
+  @Test(expected = IllegalArgumentException.class)
+  public void testParallelEdges() {
+    IntervalResidualEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(2), createEdge(2),
-				createEdge(2));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(2), createEdge(2), createEdge(2));
 
-		edges.initialize(initialEdges);
-	}
+    edges.initialize(initialEdges);
+  }
 
-	@Test
-	public void testEdgeValues() {
-		IntervalResidualEdges edges = getEdges();
-		Set<Integer> testValues = new HashSet<Integer>();
-		testValues.add(0);
-		testValues.add(Integer.MAX_VALUE / 2);
-		testValues.add(Integer.MAX_VALUE);
+  @Test
+  public void testEdgeValues() {
+    IntervalResidualEdges edges = getEdges();
+    Set<Integer> testValues = new HashSet<Integer>();
+    testValues.add(0);
+    testValues.add(Integer.MAX_VALUE / 2);
+    testValues.add(Integer.MAX_VALUE);
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = new ArrayList<Edge<IntWritable, NullWritable>>();
-		for (Integer id : testValues) {
-			initialEdges.add(createEdge(id));
-		}
+    List<Edge<IntWritable, NullWritable>> initialEdges = new ArrayList<Edge<IntWritable, NullWritable>>();
+    for (Integer id : testValues) {
+      initialEdges.add(createEdge(id));
+    }
 
-		edges.initialize(initialEdges);
+    edges.initialize(initialEdges);
 
-		Iterator<Edge<IntWritable, NullWritable>> edgeIt = edges.iterator();
-		while (edgeIt.hasNext()) {
-			int value = edgeIt.next().getTargetVertexId().get();
-			assertTrue("Unknown edge found " + value, testValues.remove(value));
-		}
-	}
+    Iterator<Edge<IntWritable, NullWritable>> edgeIt = edges.iterator();
+    while (edgeIt.hasNext()) {
+      int value = edgeIt.next().getTargetVertexId().get();
+      assertTrue("Unknown edge found " + value, testValues.remove(value));
+    }
+  }
 
-	@Test
-	public void testAddedSmallerValues() {
-		IntervalResidualEdges edges = getEdges();
+  @Test
+  public void testAddedSmallerValues() {
+    IntervalResidualEdges edges = getEdges();
 
-		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(100));
+    List<Edge<IntWritable, NullWritable>> initialEdges = Lists
+        .newArrayList(createEdge(100));
 
-		edges.initialize(initialEdges);
+    edges.initialize(initialEdges);
 
-		for (int i = 0; i < 16; i++) {
-			edges.add(createEdge(i));
-		}
+    for (int i = 0; i < 16; i++) {
+      edges.add(createEdge(i));
+    }
 
-		assertEquals(17, edges.size());
-	}
+    assertEquals(17, edges.size());
+  }
 
-	@Test
-	public void testCompressedSize() throws IOException {
-		IntervalResidualEdges edges = getEdges();
+  @Test
+  public void testCompressedSize() throws IOException {
+    IntervalResidualEdges edges = getEdges();
 
-		// Add 10 edges with id i, for i = 0..9
-		// to create on large interval
-		for (int i = 0; i < 10; ++i) {
-			edges.add(createEdge(i));
-		}
-		
-		// Add a residual edge
-		edges.add(createEdge(23));
-		
-		assertEquals(11, edges.size());
-		
-		DataOutput dataOutput = Mockito.mock(DataOutput.class);
-		edges.write(dataOutput);
+    // Add 10 edges with id i, for i = 0..9
+    // to create on large interval
+    for (int i = 0; i < 10; ++i) {
+      edges.add(createEdge(i));
+    }
 
-		// size of intervalResiduals byte array should be equal to 13:
-		// 4 (intervals' size) + 4 (index of 1st interval) + 1 (length of 1st interval) + 4 (residual)
-		ArgumentCaptor<byte[]> intervalsAndResidualsCaptop = ArgumentCaptor.forClass(byte[].class);
-		Mockito.verify(dataOutput).write(intervalsAndResidualsCaptop.capture(), Mockito.anyInt(), Mockito.anyInt());
-		assertEquals(13, intervalsAndResidualsCaptop.getValue().length);
-	}
+    // Add a residual edge
+    edges.add(createEdge(23));
+
+    assertEquals(11, edges.size());
+
+    DataOutput dataOutput = Mockito.mock(DataOutput.class);
+    edges.write(dataOutput);
+
+    // size of intervalResiduals byte array should be equal to 13:
+    // 4 (intervals' size) + 4 (index of 1st interval) + 1 (length of 1st
+    // interval)
+    // + 4 (residual)
+    ArgumentCaptor<byte[]> intervalsAndResidualsCaptop = ArgumentCaptor
+        .forClass(byte[].class);
+    Mockito.verify(dataOutput).write(intervalsAndResidualsCaptop.capture(),
+        Mockito.anyInt(), Mockito.anyInt());
+    assertEquals(13, intervalsAndResidualsCaptop.getValue().length);
+  }
 }

--- a/giraph-core/src/test/java/org/apache/giraph/edge/IntervalResidualEdgesTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/edge/IntervalResidualEdgesTest.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.giraph.edge;
+
+import com.google.common.collect.Lists;
+import org.apache.giraph.conf.GiraphConfiguration;
+import org.apache.giraph.conf.GiraphConstants;
+import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class IntervalResidualEdgesTest {
+	private static Edge<IntWritable, NullWritable> createEdge(int id) {
+		return EdgeFactory.create(new IntWritable(id));
+	}
+
+	private static void assertEdges(IntervalResidualEdges edges, int... expected) {
+		int index = 0;
+		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+			Assert.assertEquals(expected[index], edge.getTargetVertexId().get());
+			index++;
+		}
+		Assert.assertEquals(expected.length, index);
+	}
+
+	private IntervalResidualEdges getEdges() {
+		GiraphConfiguration gc = new GiraphConfiguration();
+		GiraphConstants.VERTEX_ID_CLASS.set(gc, IntWritable.class);
+		GiraphConstants.EDGE_VALUE_CLASS.set(gc, NullWritable.class);
+		ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable> conf = new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(
+				gc);
+		IntervalResidualEdges ret = new IntervalResidualEdges();
+		ret.setConf(new ImmutableClassesGiraphConfiguration<IntWritable, Writable, NullWritable>(conf));
+		return ret;
+	}
+
+	@Test
+	public void testEdges() {
+		IntervalResidualEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
+				createEdge(4));
+
+		edges.initialize(initialEdges);
+		assertEdges(edges, 1, 2, 4);
+
+		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+		assertEdges(edges, 1, 2, 3, 4); // order matters, it's an array
+
+		edges.remove(new IntWritable(2));
+		assertEdges(edges, 3, 4, 1);
+	}
+
+	@Test
+	public void testInitialize() {
+		IntervalResidualEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(1), createEdge(2),
+				createEdge(4));
+
+		edges.initialize(initialEdges);
+		assertEdges(edges, 1, 2, 4);
+
+		edges.add(EdgeFactory.createReusable(new IntWritable(3)));
+		assertEdges(edges, 1, 2, 3, 4);
+
+		edges.initialize();
+		assertEquals(0, edges.size());
+	}
+
+	@Test
+	public void testInitializeUnsorted() {
+		IntervalResidualEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(3), createEdge(4),
+				createEdge(1));
+
+		edges.initialize(initialEdges);
+		assertEdges(edges, 3, 4, 1);
+
+		edges.add(EdgeFactory.createReusable(new IntWritable(2)));
+		assertEdges(edges, 1, 2, 3, 4);
+
+		edges.initialize();
+		assertEquals(0, edges.size());
+	}
+
+	@Test
+	public void testMutateEdges() {
+		IntervalResidualEdges edges = getEdges();
+
+		edges.initialize();
+
+		// Add 10 edges with id i, for i = 0..9
+		for (int i = 0; i < 10; ++i) {
+			edges.add(createEdge(i));
+		}
+
+		// Remove edges with even id
+		for (int i = 0; i < 10; i += 2) {
+			edges.remove(new IntWritable(i));
+		}
+
+		// We should now have 5 edges
+		assertEquals(5, edges.size());
+		// The edge ids should be all odd
+		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+			assertEquals(1, edge.getTargetVertexId().get() % 2);
+		}
+	}
+
+	@Test
+	public void testSerialization() throws IOException {
+		IntervalResidualEdges edges = getEdges();
+
+		edges.initialize();
+
+		// Add 10 edges with id i, for i = 0..9
+		for (int i = 0; i < 10; ++i) {
+			edges.add(createEdge(i));
+		}
+
+		// Remove edges with even id
+		for (int i = 0; i < 10; i += 2) {
+			edges.remove(new IntWritable(i));
+		}
+
+		// We should now have 5 edges
+		assertEdges(edges, 1, 3, 5, 7, 9); // id order matter because of the implementation
+
+		ByteArrayOutputStream arrayStream = new ByteArrayOutputStream();
+		DataOutputStream tempBuffer = new DataOutputStream(arrayStream);
+
+		edges.write(tempBuffer);
+		tempBuffer.close();
+
+		byte[] binary = arrayStream.toByteArray();
+
+		assertTrue("Serialized version should not be empty ", binary.length > 0);
+
+		edges = getEdges();
+		edges.readFields(new DataInputStream(new ByteArrayInputStream(binary)));
+
+		assertEquals(5, edges.size());
+
+		int[] ids = new int[] { 1, 3, 5, 7, 9 };
+		int index = 0;
+
+		for (Edge<IntWritable, NullWritable> edge : (Iterable<Edge<IntWritable, NullWritable>>) edges) {
+			assertEquals(ids[index], edge.getTargetVertexId().get());
+			index++;
+		}
+		assertEquals(ids.length, index);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testParallelEdges() {
+		IntervalResidualEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(2), createEdge(2),
+				createEdge(2));
+
+		edges.initialize(initialEdges);
+	}
+
+	@Test
+	public void testEdgeValues() {
+		IntervalResidualEdges edges = getEdges();
+		Set<Integer> testValues = new HashSet<Integer>();
+		testValues.add(0);
+		testValues.add(Integer.MAX_VALUE / 2);
+		testValues.add(Integer.MAX_VALUE);
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = new ArrayList<Edge<IntWritable, NullWritable>>();
+		for (Integer id : testValues) {
+			initialEdges.add(createEdge(id));
+		}
+
+		edges.initialize(initialEdges);
+
+		Iterator<Edge<IntWritable, NullWritable>> edgeIt = edges.iterator();
+		while (edgeIt.hasNext()) {
+			int value = edgeIt.next().getTargetVertexId().get();
+			assertTrue("Unknown edge found " + value, testValues.remove(value));
+		}
+	}
+
+	@Test
+	public void testAddedSmallerValues() {
+		IntervalResidualEdges edges = getEdges();
+
+		List<Edge<IntWritable, NullWritable>> initialEdges = Lists.newArrayList(createEdge(100));
+
+		edges.initialize(initialEdges);
+
+		for (int i = 0; i < 16; i++) {
+			edges.add(createEdge(i));
+		}
+
+		assertEquals(17, edges.size());
+	}
+
+	@Test
+	public void testCompressedSize() throws IOException {
+		IntervalResidualEdges edges = getEdges();
+
+		// Add 10 edges with id i, for i = 0..9
+		// to create on large interval
+		for (int i = 0; i < 10; ++i) {
+			edges.add(createEdge(i));
+		}
+		
+		// Add a residual edge
+		edges.add(createEdge(23));
+		
+		assertEquals(11, edges.size());
+		
+		DataOutput dataOutput = Mockito.mock(DataOutput.class);
+		edges.write(dataOutput);
+
+		// size of intervalResiduals byte array should be equal to 13:
+		// 4 (intervals' size) + 4 (index of 1st interval) + 1 (length of 1st interval) + 4 (residual)
+		ArgumentCaptor<byte[]> intervalsAndResidualsCaptop = ArgumentCaptor.forClass(byte[].class);
+		Mockito.verify(dataOutput).write(intervalsAndResidualsCaptop.capture(), Mockito.anyInt(), Mockito.anyInt());
+		assertEquals(13, intervalsAndResidualsCaptop.getValue().length);
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -328,9 +328,10 @@ under the License.
     <dep.commons-io.version>2.1</dep.commons-io.version>
     <dep.commons-net.version>3.1</dep.commons-net.version>
     <dep.commons-lang3.version>3.4</dep.commons-lang3.version>
+    <dep.dsiutils.version>2.4.2</dep.dsiutils.version>
     <dep.facebook-swift.version>0.14.0</dep.facebook-swift.version>
     <dep.fasterxml-jackson.version>2.1.2</dep.fasterxml-jackson.version>
-    <dep.fastutil.version>6.5.4</dep.fastutil.version>
+    <dep.fastutil.version>8.1.0</dep.fastutil.version>
     <dep.google.findbugs.version>2.0.2</dep.google.findbugs.version>
     <dep.guava.version>18.0</dep.guava.version>
     <dep.hbase.version>0.94.16</dep.hbase.version>
@@ -1784,6 +1785,37 @@ under the License.
       </dependency>
       <dependency>
         <groupId>it.unimi.dsi</groupId>
+        <artifactId>dsiutils</artifactId>
+        <version>${dep.dsiutils.version}</version>
+         <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+          </exclusion>
+         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
         <version>${dep.fastutil.version}</version>
       </dependency>
@@ -1791,6 +1823,44 @@ under the License.
 	    <groupId>it.unimi.dsi</groupId>
         <artifactId>webgraph</artifactId>
         <version>${dep.webgraph.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+          </exclusion>
+          <!-- <exclusion>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+          </exclusion> -->
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.giraph</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,7 @@ under the License.
     <dep.slf4j.version>1.7.6</dep.slf4j.version>
     <dep.tinkerpop.rexter.version>2.4.0</dep.tinkerpop.rexter.version>
     <dep.typetools.version>0.2.1</dep.typetools.version>
+    <dep.webgraph.version>3.6.1</dep.webgraph.version>
     <dep.yammer-metrics.version>2.2.0</dep.yammer-metrics.version>
     <dep.yourkit-api.version>11.0.10</dep.yourkit-api.version>
     <dep.zookeeper.version>3.4.5</dep.zookeeper.version>
@@ -1785,6 +1786,11 @@ under the License.
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
         <version>${dep.fastutil.version}</version>
+      </dependency>
+      <dependency>
+	    <groupId>it.unimi.dsi</groupId>
+        <artifactId>webgraph</artifactId>
+        <version>${dep.webgraph.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.giraph</groupId>


### PR DESCRIPTION
Three compressed memory efficient OutEdges implementations to hold integer IDs. All three implementations are discussed in: Panagiotis Liakos, Katia Papakonstantinopoulou, Alex Delis: Realizing Memory-Optimized Distributed Graph Processing. IEEE Trans. Knowl. Data Eng. 30(4): 743-756 (2018).

https://issues.apache.org/jira/browse/GIRAPH-1202