### PR TITLE
Improve performance of LongByteMappingStore

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/mapping/LongByteMappingStore.java
+++ b/giraph-core/src/main/java/org/apache/giraph/mapping/LongByteMappingStore.java
@@ -129,8 +129,15 @@ public class LongByteMappingStore
     concurrentIdToBytes = null;
   }
 
+  /**
+   * Returns the number of entries in the mapping store. This is updated only
+   * after the mapping has finished loading after {@link #postFilling()} has
+   * been called.
+   *
+   * @return
+   */
   @Override
   public long getStats() {
-    return concurrentIdToBytes.size();
+    return idToBytes.size();
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/mapping/LongByteMappingStore.java
+++ b/giraph-core/src/main/java/org/apache/giraph/mapping/LongByteMappingStore.java
@@ -22,7 +22,6 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicLong;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -31,7 +30,6 @@ import org.apache.giraph.conf.GiraphConstants;
 import org.apache.hadoop.io.ByteWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Writable;
-import org.apache.log4j.Logger;
 
 import com.google.common.collect.MapMaker;
 
@@ -48,12 +46,6 @@ import com.google.common.collect.MapMaker;
 public class LongByteMappingStore
   extends DefaultImmutableClassesGiraphConfigurable<LongWritable, Writable,
   Writable> implements MappingStore<LongWritable, ByteWritable> {
-  /** Logger instance */
-  private static final Logger LOG = Logger.getLogger(
-    LongByteMappingStore.class);
-
-  /** Counts number of entries added */
-  private final AtomicLong numEntries = new AtomicLong(0);
 
   /** Id prefix to bytesArray index mapping */
   private ConcurrentMap<Long, byte[]> concurrentIdToBytes;
@@ -114,7 +106,6 @@ public class LongByteMappingStore
       }
     }
     bytes[(int) (vertexId.get() & lowerBitMask)] = target.get();
-    numEntries.getAndIncrement(); // increment count
   }
 
   @Override
@@ -140,6 +131,6 @@ public class LongByteMappingStore
 
   @Override
   public long getStats() {
-    return numEntries.longValue();
+    return concurrentIdToBytes.size();
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/mapping/LongByteMappingStore.java
+++ b/giraph-core/src/main/java/org/apache/giraph/mapping/LongByteMappingStore.java
@@ -76,6 +76,7 @@ public class LongByteMappingStore
         .concurrencyLevel(getConf().getNumInputSplitsThreads())
         .makeMap();
     idToBytes = new Long2ObjectOpenHashMap<>(upper);
+    idToBytes.defaultReturnValue(null);
   }
 
   /**
@@ -86,11 +87,12 @@ public class LongByteMappingStore
    */
   public byte getByteTarget(LongWritable vertexId) {
     long key = vertexId.get() >>> lowerOrder;
-    int suffix = (int) (vertexId.get() & lowerBitMask);
-    if (!idToBytes.containsKey(key)) {
+    byte[] bs = idToBytes.get(key);
+    if (bs == null) {
       return -1;
     }
-    return idToBytes.get(key)[suffix];
+    int suffix = (int) (vertexId.get() & lowerBitMask);
+    return bs[suffix];
   }
 
   @Override

--- a/giraph-core/src/test/java/org/apache/giraph/mapping/LongByteMappingStoreTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/mapping/LongByteMappingStoreTest.java
@@ -33,6 +33,7 @@ public class LongByteMappingStoreTest {
       store.getTarget(new LongWritable(1), new ByteWritable((byte) 777)));
     assertEquals(new ByteWritable((byte) 2),
       store.getTarget(new LongWritable(2), new ByteWritable((byte) 888)));
-    assertNull(store.getTarget(new LongWritable(3), new ByteWritable((byte) 555)));
+    assertNull(store.getTarget(new LongWritable(3),
+      new ByteWritable((byte) 555)));
   }
 }

--- a/giraph-core/src/test/java/org/apache/giraph/mapping/LongByteMappingStoreTest.java
+++ b/giraph-core/src/test/java/org/apache/giraph/mapping/LongByteMappingStoreTest.java
@@ -1,0 +1,38 @@
+package org.apache.giraph.mapping;
+
+import org.apache.giraph.conf.GiraphConfiguration;
+import org.apache.giraph.conf.GiraphConstants;
+import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
+import org.apache.hadoop.io.ByteWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class LongByteMappingStoreTest {
+
+  @Test
+  public void test() {
+    ImmutableClassesGiraphConfiguration conf =
+      new ImmutableClassesGiraphConfiguration(new GiraphConfiguration());
+    GiraphConstants.LB_MAPPINGSTORE_UPPER.setIfUnset(conf, 100);
+    GiraphConstants.LB_MAPPINGSTORE_LOWER.setIfUnset(conf, 4);
+    LongByteMappingStore store = new LongByteMappingStore();
+    store.setConf(conf);
+    store.initialize();
+    store.addEntry(new LongWritable(1), new ByteWritable((byte) 1));
+    store.addEntry(new LongWritable(2), new ByteWritable((byte) 2));
+    store.postFilling();
+
+    assertEquals((byte) 1, store.getByteTarget(new LongWritable(1)));
+    assertEquals((byte) 2, store.getByteTarget(new LongWritable(2)));
+    assertEquals((byte) -1, store.getByteTarget(new LongWritable(999)));
+
+    assertEquals(new ByteWritable((byte) 1),
+      store.getTarget(new LongWritable(1), new ByteWritable((byte) 777)));
+    assertEquals(new ByteWritable((byte) 2),
+      store.getTarget(new LongWritable(2), new ByteWritable((byte) 888)));
+    assertNull(store.getTarget(new LongWritable(3), new ByteWritable((byte) 555)));
+  }
+}


### PR DESCRIPTION
Part of the overhead comes from using an atomicinteger that's written to for every entry addition. I don't see any particular value in this keeping this counter, which incurs high overhead is it is accessed on every entry. There are better ways to update it as values are added, if we think this is useful, we can add it then.

Modified also the getByteTarget method to do one less hashmap access as per the comment by @spupyrev .

Tests
- mvn -Phadoop_facebook clean install
- mvn -Phadoop_2 clean install
- Ran jobs that read a mapping, this reduces the time to load mapping by up to 50%.

https://issues.apache.org/jira/browse/GIRAPH-1210