### PR TITLE
Deprecate some Hadoop profiles

### DIFF
--- a/README
+++ b/README
@@ -48,14 +48,6 @@ Secure Hadoop versions:
   to MapReduce) Giraph could use. You may tell maven to use this version
   with "mvn -Phadoop_2 <goals>".
 
-- Apache Hadoop 0.23.1
-
-  You may tell maven to use this version with "mvn -Phadoop_0.23 <goals>".
-
-- Apache Hadoop 0.20.203.0
-
-  You may tell maven to use this version with "mvn -Phadoop_0.20.203 <goals>".
-
 - Apache Hadoop Yarn with 2.2.0
 
   You may tell maven to use this version with "mvn -Phadoop_yarn -Dhadoop.version=2.2.0 <goals>".
@@ -65,10 +57,6 @@ Secure Hadoop versions:
   You may tell maven to use this version with "mvn -Phadoop_snapshot <goals>".
 
 Unsecure Hadoop versions:
-
-- Apache Hadoop 0.20.1, 0.20.2, 0.20.3
-
-  You may tell maven to use 0.20.2 with "mvn -Phadoop_non_secure <goals>".
 
 - Facebook Hadoop releases: https://github.com/facebook/hadoop-20, Master branch
 

--- a/giraph-core/src/main/java/org/apache/giraph/bsp/BspOutputFormat.java
+++ b/giraph-core/src/main/java/org/apache/giraph/bsp/BspOutputFormat.java
@@ -50,6 +50,8 @@ public class BspOutputFormat extends OutputFormat<Text, Text> {
 
     if (conf.hasVertexOutputFormat()) {
       conf.createWrappedVertexOutputFormat().checkOutputSpecs(context);
+      /*end[HADOOP_NON_COMMIT_JOB]*/
+
     }
     if (conf.hasEdgeOutputFormat()) {
       conf.createWrappedEdgeOutputFormat().checkOutputSpecs(context);

--- a/giraph-core/src/main/java/org/apache/giraph/bsp/BspOutputFormat.java
+++ b/giraph-core/src/main/java/org/apache/giraph/bsp/BspOutputFormat.java
@@ -50,8 +50,6 @@ public class BspOutputFormat extends OutputFormat<Text, Text> {
 
     if (conf.hasVertexOutputFormat()) {
       conf.createWrappedVertexOutputFormat().checkOutputSpecs(context);
-      /*end[HADOOP_NON_COMMIT_JOB]*/
-
     }
     if (conf.hasEdgeOutputFormat()) {
       conf.createWrappedEdgeOutputFormat().checkOutputSpecs(context);

--- a/giraph-core/src/main/java/org/apache/giraph/io/internal/WrappedEdgeOutputFormat.java
+++ b/giraph-core/src/main/java/org/apache/giraph/io/internal/WrappedEdgeOutputFormat.java
@@ -150,7 +150,6 @@ public class WrappedEdgeOutputFormat<I extends WritableComparable,
             HadoopUtils.makeJobContext(getConf(), context));
       }
 
-/*if_not[HADOOP_NON_COMMIT_JOB]*/
       @Override
       public void commitJob(JobContext context) throws IOException {
         outputCommitter.commitJob(
@@ -163,7 +162,6 @@ public class WrappedEdgeOutputFormat<I extends WritableComparable,
         outputCommitter.abortJob(
             HadoopUtils.makeJobContext(getConf(), context), state);
       }
-/*end[HADOOP_NON_COMMIT_JOB]*/
     };
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/io/internal/WrappedVertexOutputFormat.java
+++ b/giraph-core/src/main/java/org/apache/giraph/io/internal/WrappedVertexOutputFormat.java
@@ -26,9 +26,7 @@ import org.apache.giraph.job.HadoopUtils;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapreduce.JobContext;
-/*if_not[HADOOP_NON_COMMIT_JOB]*/
 import org.apache.hadoop.mapreduce.JobStatus;
-/*end[HADOOP_NON_COMMIT_JOB]*/
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
@@ -149,7 +147,6 @@ public class WrappedVertexOutputFormat<I extends WritableComparable,
             HadoopUtils.makeJobContext(getConf(), context));
       }
 
-/*if_not[HADOOP_NON_COMMIT_JOB]*/
       @Override
       public void commitJob(JobContext context) throws IOException {
         outputCommitter.commitJob(
@@ -162,7 +159,6 @@ public class WrappedVertexOutputFormat<I extends WritableComparable,
         outputCommitter.abortJob(
             HadoopUtils.makeJobContext(getConf(), context), state);
       }
-/*end[HADOOP_NON_COMMIT_JOB]*/
     };
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1206,48 +1206,6 @@ under the License.
       </dependencies>
     </profile>
 
-    <profile>
-       <id>2.1.1-SNAPSHOT</id>
-       <modules>
-         <module>giraph-dist</module>
-       </modules>
-       <properties>
-         <hadoop.version>2.1.1-SNAPSHOT</hadoop.version>
-         <munge.symbols>STATIC_SASL_SYMBOL</munge.symbols>
-         <!-- TODO: add these checks eventually -->
-         <project.enforcer.skip>true</project.enforcer.skip>
-         <giraph.maven.dependency.plugin.skip>true</giraph.maven.dependency.plugin.skip>
-         <giraph.maven.duplicate.finder.skip>true</giraph.maven.duplicate.finder.skip>
-       </properties>
-       <dependencies>
-         <!-- sorted lexicographically -->
-        <dependency>
-          <groupId>commons-configuration</groupId>
-          <artifactId>commons-configuration</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>commons-httpclient</groupId>
-          <artifactId>commons-httpclient</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-auth</artifactId>
-        </dependency>
-         <dependency>
-           <groupId>org.apache.hadoop</groupId>
-           <artifactId>hadoop-common</artifactId>
-         </dependency>
-         <dependency>
-           <groupId>org.apache.hadoop</groupId>
-           <artifactId>hadoop-mapreduce-client-common</artifactId>
-         </dependency>
-         <dependency>
-           <groupId>org.apache.hadoop</groupId>
-           <artifactId>hadoop-mapreduce-client-core</artifactId>
-         </dependency>
-       </dependencies>
-     </profile>
-
     <!-- Help keep future Hadoop versions munge-free:
          All profiles below are munge-free: avoid introducing any munge
          flags on any of the following profiles. -->

--- a/pom.xml
+++ b/pom.xml
@@ -996,56 +996,6 @@ under the License.
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>hadoop_0.20.203</id>
-      <modules>
-        <module>giraph-accumulo</module>
-        <module>giraph-hbase</module>
-        <module>giraph-hcatalog</module>
-        <module>giraph-gora</module>
-        <module>giraph-rexster</module>
-        <module>giraph-dist</module>
-      </modules>
-      <properties>
-        <hadoop.version>0.20.203.0</hadoop.version>
-        <munge.symbols>HADOOP_NON_JOBCONTEXT_IS_INTERFACE,HADOOP_1_SECURITY,HADOOP_1_SECRET_MANAGER,STATIC_SASL_SYMBOL</munge.symbols>
-      </properties>
-      <dependencies>
-        <!-- sorted lexicographically -->
-        <dependency>
-          <groupId>commons-net</groupId>
-          <artifactId>commons-net</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-core</artifactId>
-          <version>${hadoop.version}</version>
-          <scope>provided</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>org.eclipse.jdt</groupId>
-              <artifactId>core</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>org.mortbay.jetty</groupId>
-              <artifactId>jetty</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>org.mortbay.jetty</groupId>
-              <artifactId>jsp-api-2.1</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>tomcat</groupId>
-              <artifactId>jasper-compiler</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>tomcat</groupId>
-              <artifactId>jasper-runtime</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
 
     <profile>
       <id>hadoop_1</id>
@@ -1104,34 +1054,6 @@ under the License.
     </profile>
 
     <profile>
-      <id>hadoop_non_secure</id>
-      <modules>
-        <module>giraph-accumulo</module>
-        <module>giraph-hbase</module>
-        <module>giraph-hcatalog</module>
-        <module>giraph-rexster</module>
-        <module>giraph-dist</module>
-      </modules>
-      <properties>
-        <hadoop.version>0.20.2</hadoop.version>
-        <munge.symbols>HADOOP_NON_SECURE,HADOOP_NON_JOBCONTEXT_IS_INTERFACE,HADOOP_NON_COMMIT_JOB,STATIC_SASL_SYMBOL</munge.symbols>
-      </properties>
-      <dependencies>
-        <!-- sorted lexicographically -->
-        <dependency>
-          <groupId>commons-collections</groupId>
-          <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-core</artifactId>
-          <version>${hadoop.version}</version>
-          <scope>provided</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
       <id>hadoop_facebook</id>
       <modules>
         <module>giraph-block-app-8</module>
@@ -1158,40 +1080,6 @@ under the License.
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
           <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>hadoop_0.23</id>
-      <modules>
-        <module>giraph-dist</module>
-      </modules>
-      <properties>
-        <hadoop.version>0.23.1</hadoop.version>
-        <munge.symbols>HADOOP_1_SECRET_MANAGER,STATIC_SASL_SYMBOL</munge.symbols>
-        <!-- TODO: add these checks eventually -->
-        <project.enforcer.skip>true</project.enforcer.skip>
-        <giraph.maven.dependency.plugin.skip>true</giraph.maven.dependency.plugin.skip>
-        <giraph.maven.duplicate.finder.skip>true</giraph.maven.duplicate.finder.skip>
-      </properties>
-      <dependencies>
-        <!-- sorted lexicographically -->
-        <dependency>
-          <groupId>commons-net</groupId>
-          <artifactId>commons-net</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-common</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-mapreduce-client-common</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-mapreduce-client-core</artifactId>
         </dependency>
       </dependencies>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1084,67 +1084,6 @@ under the License.
       </dependencies>
     </profile>
 
-    <profile>
-      <id>hadoop_cdh4.1.2</id>
-      <modules>
-        <module>giraph-dist</module>
-      </modules>
-      <properties>
-        <hadoop.version>2.0.0-cdh4.1.2</hadoop.version> 
-        <munge.symbols>HADOOP_1_SECRET_MANAGER,STATIC_SASL_SYMBOL</munge.symbols>
-        <!-- TODO: add these checks eventually -->
-        <project.enforcer.skip>true</project.enforcer.skip>
-        <giraph.maven.dependency.plugin.skip>true</giraph.maven.dependency.plugin.skip>
-        <giraph.maven.duplicate.finder.skip>true</giraph.maven.duplicate.finder.skip>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>commons-net</groupId>
-          <artifactId>commons-net</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
-          <version>${hadoop.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
-          <version>${hadoop.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-mapreduce-client-hs</artifactId>
-          <version>${hadoop.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-mapreduce-client-core</artifactId>
-          <version>${hadoop.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-mapreduce-client-common</artifactId>
-          <version>${hadoop.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-common</artifactId>
-          <version>${hadoop.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-auth</artifactId>
-          <version>${hadoop.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-client</artifactId>
-          <version>${hadoop.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-
     <!-- This profile runs on Hadoop-2.0.3-alpha by default, but does not
       use Hadoop MapReduce v2 to set up the Giraph job. This means the Giraph
       worker/master tasks are not Mappers. Tasks are run in YARN-managed execution


### PR DESCRIPTION
Remove old hadoop profiles. This also removes any Munge symbols that were used by those profiles only.

Tests
- mvn -Phadoop_2 clean install
- mvn -Phadoop_1 clean install
- mvn -Phadoop_facebook clean install
- Ran set of jobs