### PR TITLE
GIRAPH-1211: Make retrying to send network requests after timeout optional

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -690,6 +690,15 @@ public interface GiraphConstants {
       new IntConfOption("giraph.maxRequestMilliseconds", MINUTES.toMillis(10),
           "Milliseconds for a request to complete (or else resend)");
 
+  /**
+   * Whether to resend request which timed out or fail the job if timeout
+   * happens
+   */
+  BooleanConfOption RESEND_TIMED_OUT_REQUESTS =
+      new BooleanConfOption("giraph.resendTimedOutRequests", true,
+          "Whether to resend request which timed out or fail the job if " +
+              "timeout happens");
+
   /** Netty max connection failures */
   IntConfOption NETTY_MAX_CONNECTION_FAILURES =
       new IntConfOption("giraph.nettyMaxConnectionFailures", 1000,


### PR DESCRIPTION
Summary: Using counters added in GIRAPH-1205 we were able to confirm that resending network requests after timeout almost never succeeds, so add an option to fail early instead of keep trying to resend these network requests indefinitely.

Test Plan: Made response not being sent for a specific request id, verified that with keeping default value for this new option we kept trying to resend the request, and when making it false the job failed when request timeout was noticed.