### PR TITLE
GIRAPH-1215: Make FixedCapacityHeaps work with 0 capacity

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityIntByteMinHeap.java
+++ b/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityIntByteMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacityIntByteMinHeap
    * @param value Value
    */
   public void add(int key, byte value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;

--- a/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityIntDoubleMinHeap.java
+++ b/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityIntDoubleMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacityIntDoubleMinHeap
    * @param value Value
    */
   public void add(int key, double value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;

--- a/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityIntFloatMinHeap.java
+++ b/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityIntFloatMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacityIntFloatMinHeap
    * @param value Value
    */
   public void add(int key, float value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;

--- a/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityIntIntMinHeap.java
+++ b/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityIntIntMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacityIntIntMinHeap
    * @param value Value
    */
   public void add(int key, int value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;

--- a/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityIntLongMinHeap.java
+++ b/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityIntLongMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacityIntLongMinHeap
    * @param value Value
    */
   public void add(int key, long value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;

--- a/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityLongByteMinHeap.java
+++ b/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityLongByteMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacityLongByteMinHeap
    * @param value Value
    */
   public void add(long key, byte value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;

--- a/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityLongDoubleMinHeap.java
+++ b/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityLongDoubleMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacityLongDoubleMinHeap
    * @param value Value
    */
   public void add(long key, double value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;

--- a/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityLongFloatMinHeap.java
+++ b/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityLongFloatMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacityLongFloatMinHeap
    * @param value Value
    */
   public void add(long key, float value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;

--- a/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityLongIntMinHeap.java
+++ b/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityLongIntMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacityLongIntMinHeap
    * @param value Value
    */
   public void add(long key, int value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;

--- a/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityLongLongMinHeap.java
+++ b/giraph-core/src/main/java/org/apache/giraph/types/heaps/FixedCapacityLongLongMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacityLongLongMinHeap
    * @param value Value
    */
   public void add(long key, long value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;

--- a/giraph-core/templates/FixedCapacityType2TypeMinHeap.java
+++ b/giraph-core/templates/FixedCapacityType2TypeMinHeap.java
@@ -81,7 +81,8 @@ public class FixedCapacity${type1.camel}${type2.camel}MinHeap
    * @param value Value
    */
   public void add(${type1.lower} key, ${type2.lower} value) {
-    if (size == capacity && compare(keys[0], values[0], key, value) >= 0) {
+    if (capacity == 0 ||
+        (size == capacity && compare(keys[0], values[0], key, value) >= 0)) {
       // If the heap is full and smallest element in it is not smaller
       // than value, do nothing
       return;


### PR DESCRIPTION
Currently FixedCapacityHeaps throw an exception when they are used with capacity 0, this fixes it.

Most of the diff is autogenerated, only change in FixedCapacityType2TypeMinHeap.java