### PR TITLE
Update git repo URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@ under the License.
   <inceptionYear>2011</inceptionYear>
 
   <scm>
-    <connection>scm:git:http://git-wip-us.apache.org/repos/asf/giraph.git</connection>
-    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/giraph.git</developerConnection>
-    <url>https://git-wip-us.apache.org/repos/asf/giraph.git</url>
+    <connection>scm:git:http://gitbox.apache.org/repos/asf/giraph.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/giraph.git</developerConnection>
+    <url>https://gitbox.apache.org/repos/asf/giraph.git</url>
   </scm>
 
   <ciManagement>

--- a/src/site/resources/doap_Giraph.rdf
+++ b/src/site/resources/doap_Giraph.rdf
@@ -36,8 +36,8 @@
     <category rdf:resource="http://projects.apache.org/category/big-data" />
     <repository>
       <GitRepository>
-        <location rdf:resource="https://git-wip-us.apache.org/repos/asf/giraph.git"/>
-        <browse rdf:resource="https://git-wip-us.apache.org/repos/asf/giraph.git"/>
+        <location rdf:resource="https://gitbox.apache.org/repos/asf/giraph.git"/>
+        <browse rdf:resource="https://gitbox.apache.org/repos/asf/giraph.git"/>
       </GitRepository>
     </repository>
     <maintainer>

--- a/src/site/xdoc/build.xml
+++ b/src/site/xdoc/build.xml
@@ -31,7 +31,7 @@ under the License.
 <section name="Building and Testing">
 
 <p>
-You can check out Giraph with <tt>git clone http://git-wip-us.apache.org/repos/asf/giraph.git</tt>. In order to build and test Giraph, you will need the following:</p>
+You can check out Giraph with <tt>git clone http://gitbox.apache.org/repos/asf/giraph.git</tt>. In order to build and test Giraph, you will need the following:</p>
 <ul>
   <li>Java 1.8</li>
   <li>Maven 3 or higher. Giraph uses the <a href="http://sonatype.github.com/munge-maven-plugin/">munge plugin</a>, which requires Maven 3, to support multiple versions of Hadoop. Also, the web site plugin requires Maven 3.</li>

--- a/src/site/xdoc/generating_patches.xml
+++ b/src/site/xdoc/generating_patches.xml
@@ -30,7 +30,7 @@ under the License.
   <section name="Generating patches" id="Generatingpatches">
     <p>Follow these steps to generate a patch that can be attached to a JIRA issue for review.</p>
     <ul>
-      <li>Check out the Giraph source from the <a href="http://git-wip-us.apache.org/repos/asf/giraph.git">git repository</a>.</li>
+      <li>Check out the Giraph source from the <a href="http://gitbox.apache.org/repos/asf/giraph.git">git repository</a>.</li>
       <li>Make the changes necessary for your particular issue while following the code conventions found in <tt>CODE_CONVENTIONS</tt>.  Try to avoid unnecessary changes, such as extra whitespace or formatting changes. Include a unit test, or be ready to justify in the JIRA why one isn't necessary.</li>
       <li>Verify the new and existing tests continue to pass via <tt>mvn clean verify</tt>.  This maven lifecycle will do checkstyle, findbugs, license checks (Apache Rat), and unittests.  Verify the change works as expected on a real cluster, if possible. If one's not available for testing, mention it on the JIRA so another contributor can verify.</li>
       <li>Generate a patch with <tt>git diff --no-prefix trunk > GIRAPH-{ISSUE_NUMBER}.patch</tt> (the <tt>--no-prefix</tt> option is necessary to make the patch compatible with Apache's subversion repository). For subsequent patches, if necessary, number each version to make it easier for reviewers to track their progress.</li>

--- a/src/site/xdoc/releasing_giraph.xml
+++ b/src/site/xdoc/releasing_giraph.xml
@@ -31,7 +31,7 @@ under the License.
     <p>Releasing new version of Apache Giraph may take 2 weeks or more. Please, plan accordingly.</p>
     <p>Follow these steps to release new version of Apache Giraph.</p>
     <ul>
-      <li>Check out the Giraph source from the <a href="http://git-wip-us.apache.org/repos/asf/giraph.git">git repository</a>.</li>
+      <li>Check out the Giraph source from the <a href="http://gitbox.apache.org/repos/asf/giraph.git">git repository</a>.</li>
       <li>Make a release branch <tt>git checkout -b release-1.2; git push origin release-1.2</tt></li>
       <li>Once you have a release branch, setup continuous integration in Jenkins. <a href="https://builds.apache.org/job/Giraph-1.2/">See for example a setup for Giraph 1.2 release</a></li>
       <li>Fix test cases and build errors until you have a clean build for both hadoop_1 and hadoop_2 profiles</li>


### PR DESCRIPTION
Apache Giraph has migrated to gitbox.apache.org. This updates the URLs on the site.

https://issues.apache.org/jira/browse/GIRAPH-1217

Tests:
Run `mvn -Phadoop_2  site -DskipTests` and  `mvn -Phadoop_2  site:stage -DskipTests` and verify the links are updated in the generated site.