### PR TITLE
Make number of retries in RetryableJobProgressTrackerClient configurable

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
@@ -69,7 +69,7 @@ public class RetryableJobProgressTrackerClient
   /** Job progress tracker */
   private JobProgressTracker jobProgressTracker;
   /** Cached value for number of retries */
-  private int numRetries = 1;
+  private int numRetries;
   /** Cached value for wait time between retries */
   private int retryWaitMsec;
 


### PR DESCRIPTION
Currently, the number of retries is fixed to 1. This makes the number of retries and the time to wait between retries configurable.

https://issues.apache.org/jira/projects/GIRAPH/issues/GIRAPH-1218

Tests
- mvn -Phadoop_facebook clean install
- mvn -Phadoop_2 clean install
- Ran a number of jobs

Looking at the logs, I verified that some failed methods get retried with a wait time between calls.