### PR TITLE
Improve exception handling in RetryableJobProgressTrackerClient

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
@@ -201,14 +201,22 @@ public class RetryableJobProgressTrackerClient
           retry(runnable);
           break; // If the retry succeeded, we simply break from the loop
 
-          // CHECKSTYLE: stop IllegalCatch
-        } catch (Exception e) {
-          // CHECKSTYLE: resume IllegalCatch
+        } catch (RuntimeTTransportException | RejectedExecutionException e) {
+          // If a RuntimeTTTransportException happened, then we will retry
           if (LOG.isInfoEnabled()) {
             LOG.info("Exception occurred while talking to " +
               "JobProgressTracker server after retry " + i +
               " of " + numRetries, e);
           }
+          // CHECKSTYLE: stop IllegalCatch
+        } catch (Exception e) {
+          // CHECKSTYLE: resume IllegalCatch
+          // If any other exception happened (e.g. application-specific),
+          // then we stop.
+          LOG.info("Exception occurred while talking to " +
+            "JobProgressTracker server after retry " + i +
+            " of " + numRetries + ", giving up", e);
+          break;
         }
       }
       // CHECKSTYLE: stop IllegalCatch


### PR DESCRIPTION
Currently the RetryableJobProgressTrackerClient retries on every Exception. This should happen only on RuntimeTTException or RejectedExecutionException. Otherwise, we may be retrying on to many exception. For instance, application-specific exceptions should not trigger a retry

https://issues.apache.org/jira/browse/GIRAPH-1219

Tests:
- mvn -Phadoop_facebook clean install
- mvn -Phadoop_2 clean install
- Ran a number of jobs