### PR TITLE
GIRAPH-1222: Allow output formats to have writing setup and finalization

### DIFF
--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/output/BlockOutputDesc.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/output/BlockOutputDesc.java
@@ -44,6 +44,18 @@ public interface BlockOutputDesc<OW extends BlockOutputWriter> {
   OW createOutputWriter(Configuration conf, Progressable hadoopProgressable);
 
   /**
+   * This method will be called before creating any writers
+   */
+  default void preWriting() {
+  }
+
+  /**
+   * This method will be called after all writers are closed
+   */
+  default void postWriting() {
+  }
+
+  /**
    * Commit everything
    */
   void commit();

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/output/BlockOutputHandle.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/output/BlockOutputHandle.java
@@ -52,6 +52,7 @@ public class BlockOutputHandle implements BlockOutputApi {
     outputDescMap = BlockOutputFormat.createInitAndCheckOutputDescsMap(
         conf, jobIdentifier);
     for (String confOption : outputDescMap.keySet()) {
+      outputDescMap.get(confOption).preWriting();
       freeWriters.put(confOption,
           new ConcurrentLinkedQueue<BlockOutputWriter>());
       occupiedWriters.put(confOption,
@@ -127,5 +128,9 @@ public class BlockOutputHandle implements BlockOutputApi {
     ProgressableUtils.getResultsWithNCallables(callableFactory,
         Math.min(GiraphConstants.NUM_OUTPUT_THREADS.get(conf),
             allWriters.size()), "close-writers-%d", progressable);
+    // Close all output formats
+    for (BlockOutputDesc outputDesc : outputDescMap.values()) {
+      outputDesc.postWriting();
+    }
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/io/EdgeOutputFormat.java
+++ b/giraph-core/src/main/java/org/apache/giraph/io/EdgeOutputFormat.java
@@ -20,11 +20,8 @@ package org.apache.giraph.io;
 
 import java.io.IOException;
 
-import org.apache.giraph.conf.DefaultImmutableClassesGiraphConfigurable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
-import org.apache.hadoop.mapreduce.JobContext;
-import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
 /**
@@ -38,7 +35,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 public abstract class EdgeOutputFormat<
     I extends WritableComparable, V extends Writable,
     E extends Writable> extends
-    DefaultImmutableClassesGiraphConfigurable<I, V, E> {
+    OutputFormat<I, V, E> {
   /**
    * Create an edge writer for a given split. The framework will call
    * {@link EdgeWriter#initialize(TaskAttemptContext)} before
@@ -50,33 +47,5 @@ public abstract class EdgeOutputFormat<
    * @throws InterruptedException
    */
   public abstract EdgeWriter<I, V, E> createEdgeWriter(
-    TaskAttemptContext context) throws IOException, InterruptedException;
-
-  /**
-   * Check for validity of the output-specification for the job.
-   * (Copied from Hadoop OutputFormat)
-   *
-   * <p>This is to validate the output specification for the job when it is
-   * a job is submitted.  Typically checks that it does not already exist,
-   * throwing an exception when it already exists, so that output is not
-   * overwritten.</p>
-   *
-   * @param  context information about the job
-   * @throws IOException when output should not be attempted
-   */
-  public abstract void checkOutputSpecs(JobContext context)
-    throws IOException, InterruptedException;
-
-  /**
-   * Get the output committer for this output format. This is responsible
-   * for ensuring the output is committed correctly.
-   * (Copied from Hadoop OutputFormat)
-   *
-   * @param context the task context
-   * @return an output committer
-   * @throws IOException
-   * @throws InterruptedException
-   */
-  public abstract OutputCommitter getOutputCommitter(
     TaskAttemptContext context) throws IOException, InterruptedException;
 }

--- a/giraph-core/src/main/java/org/apache/giraph/io/OutputFormat.java
+++ b/giraph-core/src/main/java/org/apache/giraph/io/OutputFormat.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.giraph.io;
+
+import org.apache.giraph.conf.DefaultImmutableClassesGiraphConfigurable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * Parent class for vertex and edge output formats
+ *
+ * @param <I> Vertex id
+ * @param <V> Vertex value
+ * @param <E> Edge value
+ */
+public abstract class OutputFormat<
+    I extends WritableComparable, V extends Writable,
+    E extends Writable> extends
+    DefaultImmutableClassesGiraphConfigurable<I, V, E> {
+  /**
+   * Check for validity of the output-specification for the job.
+   * (Copied from Hadoop OutputFormat)
+   *
+   * <p>This is to validate the output specification for the job when it is
+   * a job is submitted.  Typically checks that it does not already exist,
+   * throwing an exception when it already exists, so that output is not
+   * overwritten.</p>
+   *
+   * @param  context information about the job
+   * @throws IOException when output should not be attempted
+   */
+  public abstract void checkOutputSpecs(JobContext context)
+      throws IOException, InterruptedException;
+
+  /**
+   * Get the output committer for this output format. This is responsible
+   * for ensuring the output is committed correctly.
+   * (Copied from Hadoop OutputFormat)
+   *
+   * @param context the task context
+   * @return an output committer
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public abstract OutputCommitter getOutputCommitter(
+      TaskAttemptContext context) throws IOException, InterruptedException;
+
+  /**
+   * This method will be called before creating any writers
+   *
+   * @param context the task context
+   */
+  public void preWriting(TaskAttemptContext context) {
+  }
+
+  /**
+   * This method will be called after all writers are closed
+   *
+   * @param context the task context
+   */
+  public void postWriting(TaskAttemptContext context) {
+  }
+}

--- a/giraph-core/src/main/java/org/apache/giraph/io/VertexOutputFormat.java
+++ b/giraph-core/src/main/java/org/apache/giraph/io/VertexOutputFormat.java
@@ -20,10 +20,6 @@ package org.apache.giraph.io;
 
 import java.io.IOException;
 
-import org.apache.giraph.conf.DefaultImmutableClassesGiraphConfigurable;
-import org.apache.hadoop.mapreduce.JobContext;
-import org.apache.hadoop.mapreduce.OutputCommitter;
-
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -49,7 +45,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 public abstract class VertexOutputFormat<
     I extends WritableComparable, V extends Writable,
     E extends Writable> extends
-    DefaultImmutableClassesGiraphConfigurable<I, V, E> {
+    OutputFormat<I, V, E> {
   /**
    * Create a vertex writer for a given split. The framework will call
    * {@link VertexWriter#initialize(TaskAttemptContext)} before
@@ -61,33 +57,5 @@ public abstract class VertexOutputFormat<
    * @throws InterruptedException
    */
   public abstract VertexWriter<I, V, E> createVertexWriter(
-    TaskAttemptContext context) throws IOException, InterruptedException;
-
-  /**
-   * Check for validity of the output-specification for the job.
-   * (Copied from Hadoop OutputFormat)
-   *
-   * <p>This is to validate the output specification for the job when it is
-   * a job is submitted.  Typically checks that it does not already exist,
-   * throwing an exception when it already exists, so that output is not
-   * overwritten.</p>
-   *
-   * @param context information about the job
-   * @throws IOException when output should not be attempted
-   */
-  public abstract void checkOutputSpecs(JobContext context)
-    throws IOException, InterruptedException;
-
-  /**
-   * Get the output committer for this output format. This is responsible
-   * for ensuring the output is committed correctly.
-   * (Copied from Hadoop OutputFormat)
-   *
-   * @param context the task context
-   * @return an output committer
-   * @throws IOException
-   * @throws InterruptedException
-   */
-  public abstract OutputCommitter getOutputCommitter(
     TaskAttemptContext context) throws IOException, InterruptedException;
 }

--- a/giraph-core/src/main/java/org/apache/giraph/io/internal/WrappedEdgeOutputFormat.java
+++ b/giraph-core/src/main/java/org/apache/giraph/io/internal/WrappedEdgeOutputFormat.java
@@ -164,4 +164,14 @@ public class WrappedEdgeOutputFormat<I extends WritableComparable,
       }
     };
   }
+
+  @Override
+  public void preWriting(TaskAttemptContext context) {
+    originalOutputFormat.preWriting(context);
+  }
+
+  @Override
+  public void postWriting(TaskAttemptContext context) {
+    originalOutputFormat.postWriting(context);
+  }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/io/internal/WrappedVertexOutputFormat.java
+++ b/giraph-core/src/main/java/org/apache/giraph/io/internal/WrappedVertexOutputFormat.java
@@ -161,4 +161,14 @@ public class WrappedVertexOutputFormat<I extends WritableComparable,
       }
     };
   }
+
+  @Override
+  public void preWriting(TaskAttemptContext context) {
+    originalOutputFormat.preWriting(context);
+  }
+
+  @Override
+  public void postWriting(TaskAttemptContext context) {
+    originalOutputFormat.postWriting(context);
+  }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/io/superstep_output/MultiThreadedSuperstepOutput.java
+++ b/giraph-core/src/main/java/org/apache/giraph/io/superstep_output/MultiThreadedSuperstepOutput.java
@@ -75,6 +75,7 @@ public class MultiThreadedSuperstepOutput<I extends WritableComparable,
     this.context = context;
     availableVertexWriters = Lists.newArrayList();
     occupiedVertexWriters = Sets.newHashSet();
+    vertexOutputFormat.preWriting(context);
   }
 
   @Override
@@ -145,5 +146,6 @@ public class MultiThreadedSuperstepOutput<I extends WritableComparable,
     ProgressableUtils.getResultsWithNCallables(callableFactory,
         Math.min(configuration.getNumOutputThreads(),
             availableVertexWriters.size()), "close-writers-%d", context);
+    vertexOutputFormat.postWriting(context);
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
@@ -976,6 +976,7 @@ else[HADOOP_NON_SECURE]*/
             "using " + numThreads + " threads");
     final VertexOutputFormat<I, V, E> vertexOutputFormat =
         getConfiguration().createWrappedVertexOutputFormat();
+    vertexOutputFormat.preWriting(getContext());
 
     getPartitionStore().startIteration();
 
@@ -1050,6 +1051,8 @@ else[HADOOP_NON_SECURE]*/
     ProgressableUtils.getResultsWithNCallables(callableFactory, numThreads,
         "save-vertices-%d", getContext());
 
+    vertexOutputFormat.postWriting(getContext());
+
     LoggerUtils.setStatusAndLog(getContext(), LOG, Level.INFO,
       "saveVertices: Done saving vertices.");
     // YARN: must complete the commit the "task" output, Hadoop isn't there.
@@ -1100,6 +1103,7 @@ else[HADOOP_NON_SECURE]*/
         numThreads + " threads");
     final EdgeOutputFormat<I, V, E> edgeOutputFormat =
         conf.createWrappedEdgeOutputFormat();
+    edgeOutputFormat.preWriting(getContext());
 
     getPartitionStore().startIteration();
 
@@ -1158,6 +1162,8 @@ else[HADOOP_NON_SECURE]*/
     };
     ProgressableUtils.getResultsWithNCallables(callableFactory, numThreads,
         "save-vertices-%d", getContext());
+
+    edgeOutputFormat.postWriting(getContext());
 
     LoggerUtils.setStatusAndLog(getContext(), LOG, Level.INFO,
       "saveEdges: Done saving edges.");


### PR DESCRIPTION
Summary: Sometimes output formats need custom logic to be executed once per worker, before and after writers are being used. Add callbacks to allow for that.

Test Plan: Used with output where this is needed, verified it works as expected.