### PR TITLE
GIRAPH-1224: Allow job to succeed if input is empty

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -1317,5 +1317,12 @@ public interface GiraphConstants {
    */
   StrConfOption JMAP_PATH = new StrConfOption("giraph.jmapPath", "jmap",
           "Path to use for invoking jmap");
+
+  /**
+   * Whether to fail the job or just warn when input is empty
+   */
+  BooleanConfOption FAIL_ON_EMPTY_INPUT = new BooleanConfOption(
+      "giraph.failOnEmptyInput", true,
+      "Whether to fail the job or just warn when input is empty");
 }
 // CHECKSTYLE: resume InterfaceIsTypeCheck

--- a/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/BspServiceMaster.java
@@ -629,7 +629,7 @@ public class BspServiceMaster<I extends WritableComparable,
     List<InputSplit> splitList = generateInputSplits(inputFormat,
         minSplitCountHint, inputSplitType);
 
-    if (splitList.isEmpty()) {
+    if (splitList.isEmpty() && GiraphConstants.FAIL_ON_EMPTY_INPUT.get(conf)) {
       LOG.fatal(logPrefix + ": Failing job due to 0 input splits, " +
           "check input of " + inputFormat.getClass().getName() + "!");
       getContext().setStatus("Failing job due to 0 input splits, " +


### PR DESCRIPTION
Summary: If input is empty we always fail, but sometimes when it's part of bigger workflow we might want to let job succeed, add an option for that.

Test Plan: Ran a job with empty input which was failing before with new option set and verified it passed.