### PR TITLE
Counter Mechanism

### DIFF
--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockCounters.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockCounters.java
@@ -23,6 +23,8 @@ import org.apache.giraph.block_app.framework.api.Counter;
 import org.apache.giraph.block_app.framework.api.StatusReporter;
 import org.apache.giraph.block_app.framework.internal.BlockMasterLogic.TimeStatsPerEvent;
 
+import org.apache.giraph.counters.CustomCounter;
+import org.apache.giraph.counters.CustomCounters;
 import org.apache.hadoop.mapreduce.Mapper;
 
 /** Utility class for Blocks Framework related counters */
@@ -49,6 +51,9 @@ public class BlockCounters {
         for (Field field : fields) {
           try {
             long value = field.getLong(stage);
+            String counterName = prefix + field.getName();
+            CustomCounters.addCustomCounter(GROUP, counterName,
+                    CustomCounter.AGGREGATION.SUM);
             reporter.getCounter(
                 GROUP, prefix + field.getName()).setValue(value);
 
@@ -67,11 +72,12 @@ public class BlockCounters {
       long millis, StatusReporter reporter,
       TimeStatsPerEvent timeStats) {
     String name = masterPiece.getPiece().toString();
-    reporter.getCounter(
-        GROUP + " Master Timers",
-        String.format(
-            "In %6.1f %s (s)", superstep - 0.5, name)
-    ).setValue(millis / 1000);
+    String groupName = GROUP + " Master Timers";
+    String counterName = String.format(
+            "In %6.1f %s (s)", superstep - 0.5, name);
+    CustomCounters.addCustomCounter(groupName, counterName,
+            CustomCounter.AGGREGATION.SUM);
+    reporter.getCounter(groupName, counterName).setValue(millis / 1000);
     timeStats.inc(name, millis);
   }
 
@@ -80,10 +86,11 @@ public class BlockCounters {
       long millis, StatusReporter reporter,
       TimeStatsPerEvent timeStats) {
     String name = workerPieces.toStringShort();
-    reporter.getCounter(
-        GROUP + " Worker Timers",
-        String.format("In %6d %s (s)", superstep, name)
-    ).setValue(millis / 1000);
+    String groupName = GROUP + " Worker Timers";
+    String counterName = String.format("In %6d %s (s)", superstep, name);
+    CustomCounters.addCustomCounter(groupName, counterName,
+            CustomCounter.AGGREGATION.SUM);
+    reporter.getCounter(groupName, counterName).setValue(millis / 1000);
     timeStats.inc(name, millis);
   }
 

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockCounters.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockCounters.java
@@ -53,7 +53,7 @@ public class BlockCounters {
             long value = field.getLong(stage);
             String counterName = prefix + field.getName();
             CustomCounters.addCustomCounter(GROUP, counterName,
-                    CustomCounter.AGGREGATION.SUM);
+                    CustomCounter.Aggregation.SUM);
             reporter.getCounter(
                 GROUP, prefix + field.getName()).setValue(value);
 
@@ -76,7 +76,7 @@ public class BlockCounters {
     String counterName = String.format(
             "In %6.1f %s (s)", superstep - 0.5, name);
     CustomCounters.addCustomCounter(groupName, counterName,
-            CustomCounter.AGGREGATION.SUM);
+            CustomCounter.Aggregation.SUM);
     reporter.getCounter(groupName, counterName).setValue(millis / 1000);
     timeStats.inc(name, millis);
   }
@@ -89,7 +89,7 @@ public class BlockCounters {
     String groupName = GROUP + " Worker Timers";
     String counterName = String.format("In %6d %s (s)", superstep, name);
     CustomCounters.addCustomCounter(groupName, counterName,
-            CustomCounter.AGGREGATION.SUM);
+            CustomCounter.Aggregation.SUM);
     reporter.getCounter(groupName, counterName).setValue(millis / 1000);
     timeStats.inc(name, millis);
   }

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockWorkerPieces.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockWorkerPieces.java
@@ -27,6 +27,8 @@ import org.apache.giraph.conf.DefaultMessageClasses;
 import org.apache.giraph.conf.GiraphConstants;
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
 import org.apache.giraph.conf.MessageClasses;
+import org.apache.giraph.counters.CustomCounter;
+import org.apache.giraph.counters.CustomCounters;
 import org.apache.giraph.factories.DefaultMessageValueFactory;
 import org.apache.giraph.master.MasterCompute;
 import org.apache.giraph.types.NoMessage;
@@ -50,6 +52,16 @@ public class BlockWorkerPieces<S> {
   /** Aggregator holding next worker computation */
   private static final
   String NEXT_WORKER_PIECES = "giraph.blocks.next_worker_pieces";
+
+  /** Passed worker stats counter group */
+  private static final String PASSED_WORKER_STATS_GROUP = "PassedWorker Stats";
+
+  /** Total serialised size counter name */
+  private static final String TOTAL_SERIALISED_SIZE_NAME =
+          "total serialized size";
+
+  /** Split parts counter name */
+  private static final String SPLIT_PARTS_NAME = "split parts";
 
   private final PairedPieceAndStage<S> receiver;
   private final PairedPieceAndStage<S> sender;
@@ -135,11 +147,14 @@ public class BlockWorkerPieces<S> {
 
     LOG.info("Next worker piece - total serialized size: " + data.length +
         ", split into " + splittedData.size());
-    master.getContext().getCounter(
-        "PassedWorker Stats", "total serialized size")
+    CustomCounters.addCustomCounter(PASSED_WORKER_STATS_GROUP,
+            TOTAL_SERIALISED_SIZE_NAME, CustomCounter.AGGREGATION.SUM);
+    master.getContext().getCounter(PASSED_WORKER_STATS_GROUP,
+            TOTAL_SERIALISED_SIZE_NAME)
         .increment(data.length);
-    master.getContext().getCounter(
-        "PassedWorker Stats", "split parts")
+    CustomCounters.addCustomCounter(PASSED_WORKER_STATS_GROUP,
+            SPLIT_PARTS_NAME, CustomCounter.AGGREGATION.SUM);
+    master.getContext().getCounter(PASSED_WORKER_STATS_GROUP, SPLIT_PARTS_NAME)
         .increment(splittedData.size());
 
     master.broadcast(NEXT_WORKER_PIECES, new IntWritable(splittedData.size()));

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockWorkerPieces.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockWorkerPieces.java
@@ -148,12 +148,12 @@ public class BlockWorkerPieces<S> {
     LOG.info("Next worker piece - total serialized size: " + data.length +
         ", split into " + splittedData.size());
     CustomCounters.addCustomCounter(PASSED_WORKER_STATS_GROUP,
-            TOTAL_SERIALISED_SIZE_NAME, CustomCounter.AGGREGATION.SUM);
+            TOTAL_SERIALISED_SIZE_NAME, CustomCounter.Aggregation.SUM);
     master.getContext().getCounter(PASSED_WORKER_STATS_GROUP,
             TOTAL_SERIALISED_SIZE_NAME)
         .increment(data.length);
     CustomCounters.addCustomCounter(PASSED_WORKER_STATS_GROUP,
-            SPLIT_PARTS_NAME, CustomCounter.AGGREGATION.SUM);
+            SPLIT_PARTS_NAME, CustomCounter.Aggregation.SUM);
     master.getContext().getCounter(PASSED_WORKER_STATS_GROUP, SPLIT_PARTS_NAME)
         .increment(splittedData.size());
 

--- a/giraph-core/src/main/java/org/apache/giraph/bsp/BspService.java
+++ b/giraph-core/src/main/java/org/apache/giraph/bsp/BspService.java
@@ -92,6 +92,10 @@ public abstract class BspService<I extends WritableComparable,
   public static final String MASTER_ELECTION_DIR = "/_masterElectionDir";
   /** Superstep scope */
   public static final String SUPERSTEP_DIR = "/_superstepDir";
+  /** Counter sub directory */
+  public static final String COUNTERS_DIR = "/_counters";
+  /** Metrics sub directory */
+  public static final String METRICS_DIR = "/_metrics";
   /** Healthy workers register here. */
   public static final String WORKER_HEALTHY_DIR = "/_workerHealthyDir";
   /** Unhealthy workers register here. */
@@ -248,8 +252,10 @@ public abstract class BspService<I extends WritableComparable,
     this.graphPartitionerFactory = conf.createGraphPartitioner();
 
     basePath = ZooKeeperManager.getBasePath(conf) + BASE_DIR + "/" + jobId;
-    getContext().getCounter(GiraphConstants.ZOOKEEPER_BASE_PATH_COUNTER_GROUP,
-        basePath);
+    if (LOG.isInfoEnabled()) {
+      LOG.info(String.format("%s: %s",
+              GiraphConstants.ZOOKEEPER_BASE_PATH_COUNTER_GROUP, basePath));
+    }
     masterJobStatePath = basePath + MASTER_JOB_STATE_NODE;
     inputSplitsWorkerDonePath = basePath + INPUT_SPLITS_WORKER_DONE_DIR;
     inputSplitsAllDonePath = basePath + INPUT_SPLITS_ALL_DONE_NODE;
@@ -425,11 +431,20 @@ public abstract class BspService<I extends WritableComparable,
    *
    * @param attempt application attempt number
    * @param superstep superstep to use
+   * @param readWriteCounters Boolean to denote whether we are
+   *                          reading/writing counters
    * @return directory path based on the a superstep
    */
-  public final String getWorkerFinishedPath(long attempt, long superstep) {
-    return applicationAttemptsPath + "/" + attempt +
+  public final String getWorkerFinishedPath(long attempt, long superstep,
+                                            boolean readWriteCounters) {
+    String finishedDir = applicationAttemptsPath + "/" + attempt +
         SUPERSTEP_DIR + "/" + superstep + WORKER_FINISHED_DIR;
+    if (readWriteCounters) {
+      finishedDir += COUNTERS_DIR;
+    } else {
+      finishedDir += METRICS_DIR;
+    }
+    return finishedDir;
   }
 
   /**

--- a/giraph-core/src/main/java/org/apache/giraph/bsp/BspService.java
+++ b/giraph-core/src/main/java/org/apache/giraph/bsp/BspService.java
@@ -944,7 +944,8 @@ public abstract class BspService<I extends WritableComparable,
       eventProcessed = true;
     } else if (event.getPath().endsWith(COUNTERS_DIR) &&
             event.getType() == EventType.NodeChildrenChanged) {
-      writtenCountersToZK.signal();
+      LOG.info("process: writtenCountersToZK signaled");
+      getWrittenCountersToZKEvent().signal();
       eventProcessed = true;
     }
 

--- a/giraph-core/src/main/java/org/apache/giraph/bsp/CentralizedServiceMaster.java
+++ b/giraph-core/src/main/java/org/apache/giraph/bsp/CentralizedServiceMaster.java
@@ -180,4 +180,10 @@ public interface CentralizedServiceMaster<I extends WritableComparable,
    */
   void cleanup(SuperstepState superstepState)
     throws IOException, InterruptedException;
+
+  /**
+   * Add the Giraph Timers to thirft counter struct, and send to the job client
+   *
+   */
+  void addGiraphTimersAndSendCounters();
 }

--- a/giraph-core/src/main/java/org/apache/giraph/bsp/CentralizedServiceWorker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/bsp/CentralizedServiceWorker.java
@@ -256,4 +256,19 @@ public interface CentralizedServiceWorker<I extends WritableComparable,
    */
   void addressesAndPartitionsReceived(
       AddressesAndPartitionsWritable addressesAndPartitions);
+
+  /**
+   * Send the counter values to the master after every superstep
+   * and also after all supersteps are done. This is called before closing
+   * the zookeeper. We need to call this method after calling cleanup on the
+   * worker, since some counters are updated during cleanup
+   * @param allSuperstepsDone boolean value whether all the supersteps
+   *                          are completed
+   */
+  void storeCountersInZooKeeper(boolean allSuperstepsDone);
+
+  /**
+   * Close zookeeper
+   */
+  void closeZooKeeper();
 }

--- a/giraph-core/src/main/java/org/apache/giraph/bsp/CentralizedServiceWorker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/bsp/CentralizedServiceWorker.java
@@ -258,7 +258,7 @@ public interface CentralizedServiceWorker<I extends WritableComparable,
       AddressesAndPartitionsWritable addressesAndPartitions);
 
   /**
-   * Send the counter values to the master after every superstep
+   * Store the counter values in the zookeeper after every superstep
    * and also after all supersteps are done. This is called before closing
    * the zookeeper. We need to call this method after calling cleanup on the
    * worker, since some counters are updated during cleanup

--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConfiguration.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConfiguration.java
@@ -1088,6 +1088,10 @@ public class GiraphConfiguration extends Configuration
     return MAX_MASTER_SUPERSTEP_WAIT_MSECS.get(this);
   }
 
+  public int getMaxCounterWaitMsecs() {
+    return MAX_COUNTER_WAIT_MSECS.get(this);
+  }
+
   /**
    * Set the maximum milliseconds to wait before giving up trying to get the
    * minimum number of workers before a superstep.

--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -687,6 +687,16 @@ public interface GiraphConstants {
           "Maximum milliseconds to wait before giving up trying to get the " +
           "minimum number of workers before a superstep (int).");
 
+  /**
+   * Maximum milliseconds to wait before giving up waiting for the workers to
+   * write the counters to the Zookeeper after a superstep
+   */
+  IntConfOption MAX_COUNTER_WAIT_MSECS = new IntConfOption(
+          "giraph.maxCounterWaitMsecs", MINUTES.toMillis(2),
+          "Maximum milliseconds to wait before giving up waiting for" +
+                  "the workers to write their counters to the " +
+                  "zookeeper after a superstep");
+
   /** Milliseconds for a request to complete (or else resend) */
   IntConfOption MAX_REQUEST_MILLISECONDS =
       new IntConfOption("giraph.maxRequestMilliseconds", MINUTES.toMillis(10),

--- a/giraph-core/src/main/java/org/apache/giraph/counters/CustomCounter.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/CustomCounter.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.giraph.counters;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+import org.apache.hadoop.io.Writable;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * An object of this class represents a counter with a group name,
+ * counter name, value, and type of aggregation to be performed
+ *
+ */
+@ThriftStruct
+public class CustomCounter implements Writable, Comparable {
+
+  /** Counter group name */
+  private String groupName;
+
+  /** Counter name */
+  private String counterName;
+
+  /** Type of aggregation for counter */
+  private AGGREGATION aggregation;
+
+  /** Counter value */
+  private long value;
+
+  /** To store the type of aggregation to be done on the counters */
+  public enum AGGREGATION {
+    /** Sum */
+    SUM,
+    /** Max */
+    MAX,
+    /** Min */
+    MIN,
+    /** No op */
+    NOOP
+  }
+
+  /**
+   * Create a default custom counter
+   *
+   */
+  public CustomCounter() {
+    groupName = "";
+    counterName = "";
+    aggregation = AGGREGATION.NOOP;
+    value = 0;
+  }
+
+  /**
+   * Create a counter with a given group, name, and aggregation type
+   * The default value is 0
+   *
+   * @param groupName Group name
+   * @param counterName Counter name
+   * @param aggregation Aggregation type
+   */
+  public CustomCounter(String groupName, String counterName,
+                       AGGREGATION aggregation) {
+    this(groupName, counterName, aggregation, 0);
+  }
+
+  /**
+   * Create a counter with a group, name, aggregation type, and value
+   * @param groupName Group name
+   * @param counterName Counter name
+   * @param aggregation Aggregation type
+   * @param value Value
+   */
+  public CustomCounter(String groupName, String counterName,
+                       AGGREGATION aggregation, long value) {
+    this.groupName = groupName;
+    this.counterName = counterName;
+    this.aggregation = aggregation;
+    this.value = value;
+  }
+
+  @ThriftField(1)
+  public String getGroupName() {
+    return groupName;
+  }
+
+  @ThriftField
+  public void setGroupName(String groupName) {
+    this.groupName = groupName;
+  }
+
+  @ThriftField(2)
+  public String getCounterName() {
+    return counterName;
+  }
+
+  @ThriftField
+  public void setCounterName(String counterName) {
+    this.counterName = counterName;
+  }
+
+  @ThriftField(3)
+  public AGGREGATION getAggregation() {
+    return aggregation;
+  }
+
+  @ThriftField
+  public void setAggregation(AGGREGATION aggregation) {
+    this.aggregation = aggregation;
+  }
+
+  @ThriftField(4)
+  public long getValue() {
+    return value;
+  }
+
+  @ThriftField
+  public void setValue(long value) {
+    this.value = value;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 29;
+    int result = 1;
+    result = prime * result + getGroupName().hashCode();
+    result = prime * result + getCounterName().hashCode();
+    result = prime * result + getAggregation().hashCode();
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof CustomCounter) {
+      CustomCounter customCounter = (CustomCounter) other;
+      if (getGroupName().equalsIgnoreCase(customCounter.getGroupName()) &&
+            getCounterName().equalsIgnoreCase(customCounter.getCounterName()) &&
+            getAggregation().name().equalsIgnoreCase(
+                    customCounter.getAggregation().name())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void write(DataOutput output) throws IOException {
+    output.writeUTF(groupName);
+    output.writeUTF(counterName);
+    output.writeUTF(aggregation.name());
+    output.writeLong(value);
+  }
+
+  @Override
+  public void readFields(DataInput input) throws IOException {
+    groupName = input.readUTF();
+    counterName = input.readUTF();
+    aggregation = AGGREGATION.valueOf(input.readUTF());
+    value = input.readLong();
+  }
+
+  @Override
+  public int compareTo(Object o) {
+    CustomCounter c2 = (CustomCounter) o;
+    int compare = getGroupName().compareToIgnoreCase(c2.getGroupName());
+    if (compare == 0) {
+      return getCounterName().compareToIgnoreCase(c2.getCounterName());
+    }
+    return compare;
+  }
+}

--- a/giraph-core/src/main/java/org/apache/giraph/counters/CustomCounter.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/CustomCounter.java
@@ -40,13 +40,13 @@ public class CustomCounter implements Writable, Comparable {
   private String counterName;
 
   /** Type of aggregation for counter */
-  private AGGREGATION aggregation;
+  private Aggregation aggregation;
 
   /** Counter value */
   private long value;
 
   /** To store the type of aggregation to be done on the counters */
-  public enum AGGREGATION {
+  public enum Aggregation {
     /** Sum */
     SUM,
     /** Max */
@@ -64,7 +64,7 @@ public class CustomCounter implements Writable, Comparable {
   public CustomCounter() {
     groupName = "";
     counterName = "";
-    aggregation = AGGREGATION.NOOP;
+    aggregation = Aggregation.NOOP;
     value = 0;
   }
 
@@ -77,7 +77,7 @@ public class CustomCounter implements Writable, Comparable {
    * @param aggregation Aggregation type
    */
   public CustomCounter(String groupName, String counterName,
-                       AGGREGATION aggregation) {
+                       Aggregation aggregation) {
     this(groupName, counterName, aggregation, 0);
   }
 
@@ -89,7 +89,7 @@ public class CustomCounter implements Writable, Comparable {
    * @param value Value
    */
   public CustomCounter(String groupName, String counterName,
-                       AGGREGATION aggregation, long value) {
+                       Aggregation aggregation, long value) {
     this.groupName = groupName;
     this.counterName = counterName;
     this.aggregation = aggregation;
@@ -117,12 +117,12 @@ public class CustomCounter implements Writable, Comparable {
   }
 
   @ThriftField(3)
-  public AGGREGATION getAggregation() {
+  public Aggregation getAggregation() {
     return aggregation;
   }
 
   @ThriftField
-  public void setAggregation(AGGREGATION aggregation) {
+  public void setAggregation(Aggregation aggregation) {
     this.aggregation = aggregation;
   }
 
@@ -172,7 +172,7 @@ public class CustomCounter implements Writable, Comparable {
   public void readFields(DataInput input) throws IOException {
     groupName = input.readUTF();
     counterName = input.readUTF();
-    aggregation = AGGREGATION.valueOf(input.readUTF());
+    aggregation = Aggregation.valueOf(input.readUTF());
     value = input.readLong();
   }
 

--- a/giraph-core/src/main/java/org/apache/giraph/counters/CustomCounters.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/CustomCounters.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.giraph.counters;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Custom counters created by the client or app
+ * Stores the names of the counters, and the final aggregated values
+ * Since there is no way to get the list of available counters from the context,
+ * we need to call addCustomCounter to store the information about the list of
+ * available counters. This is accessed by the worker/master to fetch the
+ * final counter values based on the group and counter name.
+ * It is assumed that whenever a counter is created, addCustomCounter is called,
+ * to enable aggregations on that counter, using the Giraph mechanism for
+ * aggregating counters.
+ */
+public class CustomCounters {
+
+
+
+  /** Unique counter groups and names populated during execution of the job */
+  private static Set<CustomCounter> COUNTER_NAMES = new HashSet<>();
+
+  /** Aggregated counter values updated by master */
+  private final List<CustomCounter> counterList;
+
+  /**
+   * Create custom counters
+   */
+  public CustomCounters() {
+    counterList = new ArrayList<>();
+  }
+
+  /**
+   * Add a counter group and name to the custom counters
+   * If it already exists, then it will not be added
+   * This will be called from the application to add the app-specific counters
+   *
+   * @param groupName Counter group
+   * @param counterName Counter name
+   * @param aggregation Type of aggregation for the counter
+   */
+  public static void addCustomCounter(String groupName, String counterName,
+                                      CustomCounter.AGGREGATION aggregation) {
+    CustomCounter counter = new CustomCounter(
+            groupName, counterName, aggregation);
+    COUNTER_NAMES.add(counter);
+  }
+
+  /**
+   * Get the unique counter group and names
+   *
+   * @return Map of unique counter names
+   */
+  public static Set<CustomCounter> getCustomCounters() {
+    // Create a new HashSet and return that to avoid
+    // ConcurrentModificationException
+    return new HashSet<>(COUNTER_NAMES);
+  }
+
+  /**
+   * Merge the incoming counter values with the existing counters
+   * This will be called by the master when it gets all the counters from
+   * different workers, and needs to aggregate them.
+   *
+   * @param newCounters List of new counter names and values
+   */
+  public void mergeCounters(Set<CustomCounter> newCounters) {
+    for (CustomCounter customCounter : newCounters) {
+      int index = counterList.indexOf(customCounter);
+      if (index == -1) {
+        // counter is not present, then append to list
+        counterList.add(customCounter);
+      } else {
+        long newValue = customCounter.getValue();
+        long oldValue = counterList.get(index).getValue();
+        CustomCounter oldCounter = counterList.get(index);
+        switch (customCounter.getAggregation()) {
+        case SUM:
+          newValue = newValue + oldValue;
+          break;
+        case MAX:
+          newValue = Math.max(newValue, oldValue);
+          break;
+        case MIN:
+          newValue = Math.min(newValue, oldValue);
+          break;
+        default:
+          // no op
+        }
+        oldCounter.setValue(newValue);
+      }
+    }
+  }
+
+  /**
+   * Get the counter list
+   *
+   * @return List of counter names and values
+   */
+  public List<CustomCounter> getCounterList() {
+    return this.counterList;
+  }
+}

--- a/giraph-core/src/main/java/org/apache/giraph/counters/CustomCounters.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/CustomCounters.java
@@ -19,9 +19,9 @@
 package org.apache.giraph.counters;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Custom counters created by the client or app
@@ -38,8 +38,12 @@ public class CustomCounters {
 
 
 
-  /** Unique counter groups and names populated during execution of the job */
-  private static Set<CustomCounter> COUNTER_NAMES = new HashSet<>();
+  /** Unique counter groups and names populated during execution of the job
+   * Since multiple threads can access this variable to perform read/write
+   * operations, we use a ConcurrentHashMap.newKeySet() to
+   * establish synchronisation */
+  private static Set<CustomCounter> COUNTER_NAMES =
+          ConcurrentHashMap.newKeySet();
 
   /** Aggregated counter values updated by master */
   private final List<CustomCounter> counterList;
@@ -61,7 +65,7 @@ public class CustomCounters {
    * @param aggregation Type of aggregation for the counter
    */
   public static void addCustomCounter(String groupName, String counterName,
-                                      CustomCounter.AGGREGATION aggregation) {
+                                      CustomCounter.Aggregation aggregation) {
     CustomCounter counter = new CustomCounter(
             groupName, counterName, aggregation);
     COUNTER_NAMES.add(counter);
@@ -75,7 +79,7 @@ public class CustomCounters {
   public static Set<CustomCounter> getCustomCounters() {
     // Create a new HashSet and return that to avoid
     // ConcurrentModificationException
-    return new HashSet<>(COUNTER_NAMES);
+    return COUNTER_NAMES;
   }
 
   /**

--- a/giraph-core/src/main/java/org/apache/giraph/counters/CustomCounters.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/CustomCounters.java
@@ -77,8 +77,6 @@ public class CustomCounters {
    * @return Map of unique counter names
    */
   public static Set<CustomCounter> getCustomCounters() {
-    // Create a new HashSet and return that to avoid
-    // ConcurrentModificationException
     return COUNTER_NAMES;
   }
 

--- a/giraph-core/src/main/java/org/apache/giraph/counters/GiraphCountersThriftStruct.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/GiraphCountersThriftStruct.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.giraph.counters;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Stores the information about the counter names and values
+ */
+@ThriftStruct
+public final class GiraphCountersThriftStruct {
+  /** Singleton instance for everyone to use */
+  private static final GiraphCountersThriftStruct INSTANCE =
+          new GiraphCountersThriftStruct();
+
+  /** Map of counter names and values */
+  private List<CustomCounter> counters = new ArrayList<>();
+
+  /**
+   * Public constructor for thrift to create us.
+   * Please use GiraphCountersThriftStruct.get() to get the static instance.
+   */
+  public GiraphCountersThriftStruct() {
+  }
+
+  /**
+   * Get singleton instance of GiraphCountersThriftStruct.
+   *
+   * @return GiraphCountersThriftStruct singleton instance
+   */
+  public static GiraphCountersThriftStruct get() {
+    return INSTANCE;
+  }
+
+  @ThriftField(1)
+  public List<CustomCounter> getCounters() {
+    return counters;
+  }
+
+  @ThriftField
+  public void setCounters(List<CustomCounter> counters) {
+    this.counters = counters;
+  }
+}

--- a/giraph-core/src/main/java/org/apache/giraph/counters/GiraphCountersThriftStruct.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/GiraphCountersThriftStruct.java
@@ -29,9 +29,6 @@ import java.util.List;
  */
 @ThriftStruct
 public final class GiraphCountersThriftStruct {
-  /** Singleton instance for everyone to use */
-  private static final GiraphCountersThriftStruct INSTANCE =
-          new GiraphCountersThriftStruct();
 
   /** Map of counter names and values */
   private List<CustomCounter> counters = new ArrayList<>();
@@ -41,15 +38,6 @@ public final class GiraphCountersThriftStruct {
    * Please use GiraphCountersThriftStruct.get() to get the static instance.
    */
   public GiraphCountersThriftStruct() {
-  }
-
-  /**
-   * Get singleton instance of GiraphCountersThriftStruct.
-   *
-   * @return GiraphCountersThriftStruct singleton instance
-   */
-  public static GiraphCountersThriftStruct get() {
-    return INSTANCE;
   }
 
   @ThriftField(1)

--- a/giraph-core/src/main/java/org/apache/giraph/counters/GiraphStats.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/GiraphStats.java
@@ -165,7 +165,7 @@ public class GiraphStats extends HadoopCountersBase {
     for (int i = 0; i < counters.length; i++) {
       counterList.add(new CustomCounter(GROUP_NAME,
               counters[i].getDisplayName(),
-              CustomCounter.AGGREGATION.SUM, counters[i].getValue()));
+              CustomCounter.Aggregation.SUM, counters[i].getValue()));
     }
     return counterList;
   }

--- a/giraph-core/src/main/java/org/apache/giraph/counters/GiraphStats.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/GiraphStats.java
@@ -20,8 +20,10 @@ package org.apache.giraph.counters;
 
 import org.apache.hadoop.mapreduce.Mapper.Context;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Hadoop Counters in group "Giraph Stats". General statistics about job.
@@ -149,6 +151,23 @@ public class GiraphStats extends HadoopCountersBase {
    */
   public static GiraphStats getInstance() {
     return INSTANCE;
+  }
+
+
+  /**
+   * Get a map of counter names, and values
+   * To be used by the master to send to the job client
+   *
+   * @return Map of counter names and values
+   */
+  public List<CustomCounter> getCounterList() {
+    List<CustomCounter> counterList = new ArrayList<>();
+    for (int i = 0; i < counters.length; i++) {
+      counterList.add(new CustomCounter(GROUP_NAME,
+              counters[i].getDisplayName(),
+              CustomCounter.AGGREGATION.SUM, counters[i].getValue()));
+    }
+    return counterList;
   }
 
   /**

--- a/giraph-core/src/main/java/org/apache/giraph/counters/GiraphTimers.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/GiraphTimers.java
@@ -193,14 +193,14 @@ public class GiraphTimers extends HadoopCountersBase {
     for (GiraphHadoopCounter counter: jobCounters) {
       CustomCounter customCounter = new CustomCounter(
               GROUP_NAME, counter.getName(),
-              CustomCounter.AGGREGATION.SUM, counter.getValue());
+              CustomCounter.Aggregation.SUM, counter.getValue());
       countersList.add(customCounter);
     }
     for (Map.Entry<Long, GiraphHadoopCounter> entry :
             superstepMsec.entrySet()) {
       CustomCounter customCounter = new CustomCounter(
               GROUP_NAME, entry.getValue().getName(),
-              CustomCounter.AGGREGATION.SUM, entry.getValue().getValue());
+              CustomCounter.Aggregation.SUM, entry.getValue().getValue());
       countersList.add(customCounter);
     }
     return countersList;

--- a/giraph-core/src/main/java/org/apache/giraph/counters/GiraphTimers.java
+++ b/giraph-core/src/main/java/org/apache/giraph/counters/GiraphTimers.java
@@ -23,8 +23,10 @@ import org.apache.hadoop.mapreduce.Mapper.Context;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -179,5 +181,28 @@ public class GiraphTimers extends HadoopCountersBase {
   public Iterator<GiraphHadoopCounter> iterator() {
     return Iterators.concat(jobCounters().iterator(),
         superstepCounters().values().iterator());
+  }
+
+  /**
+   * Get a map of counter names and values
+   *
+   * @return Map of counter names and values
+   */
+  public List<CustomCounter> getCounterList() {
+    List<CustomCounter> countersList = new ArrayList<>();
+    for (GiraphHadoopCounter counter: jobCounters) {
+      CustomCounter customCounter = new CustomCounter(
+              GROUP_NAME, counter.getName(),
+              CustomCounter.AGGREGATION.SUM, counter.getValue());
+      countersList.add(customCounter);
+    }
+    for (Map.Entry<Long, GiraphHadoopCounter> entry :
+            superstepMsec.entrySet()) {
+      CustomCounter customCounter = new CustomCounter(
+              GROUP_NAME, entry.getValue().getName(),
+              CustomCounter.AGGREGATION.SUM, entry.getValue().getValue());
+      countersList.add(customCounter);
+    }
+    return countersList;
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/graph/GraphMapper.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/GraphMapper.java
@@ -77,6 +77,7 @@ public class GraphMapper<I extends WritableComparable, V extends Writable,
   public void cleanup(Context context)
     throws IOException, InterruptedException {
     graphTaskManager.cleanup();
+    graphTaskManager.sendWorkerCountersAndFinishCleanup();
   }
 
   @Override

--- a/giraph-core/src/main/java/org/apache/giraph/graph/GraphTaskManager.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/GraphTaskManager.java
@@ -987,7 +987,18 @@ end[PURE_YARN]*/
 
     if (serviceWorker != null) {
       serviceWorker.cleanup(finishedSuperstepStats);
+    }
+  }
+
+  /**
+   * Method to send the counter values from the worker to the master,
+   * after all supersteps are done, and finish cleanup
+   */
+  public void sendWorkerCountersAndFinishCleanup() {
+    if (serviceWorker != null) {
       postSaveOnWorkerObservers();
+      serviceWorker.storeCountersInZooKeeper(true);
+      serviceWorker.closeZooKeeper();
     }
     try {
       if (masterThread != null) {
@@ -1002,15 +1013,15 @@ end[PURE_YARN]*/
       LOG.info("cleanup: Offlining ZooKeeper servers");
       try {
         zkManager.offlineZooKeeperServers(ZooKeeperManager.State.FINISHED);
-      // We need this here cause apparently exceptions are eaten by Hadoop
-      // when they come from the cleanup lifecycle and it's useful to know
-      // if something is wrong.
-      //
-      // And since it's cleanup nothing too bad should happen if we don't
-      // propagate and just allow the job to finish normally.
-      // CHECKSTYLE: stop IllegalCatch
+        // We need this here cause apparently exceptions are eaten by Hadoop
+        // when they come from the cleanup lifecycle and it's useful to know
+        // if something is wrong.
+        //
+        // And since it's cleanup nothing too bad should happen if we don't
+        // propagate and just allow the job to finish normally.
+        // CHECKSTYLE: stop IllegalCatch
       } catch (Throwable e) {
-      // CHECKSTYLE: resume IllegalCatch
+        // CHECKSTYLE: resume IllegalCatch
         LOG.error("cleanup: Error offlining zookeeper", e);
       }
     }

--- a/giraph-core/src/main/java/org/apache/giraph/graph/JobProgressTrackerClientNoOp.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/JobProgressTrackerClientNoOp.java
@@ -19,6 +19,7 @@
 package org.apache.giraph.graph;
 
 import org.apache.giraph.conf.GiraphConfiguration;
+import org.apache.giraph.counters.GiraphCountersThriftStruct;
 import org.apache.giraph.master.MasterProgress;
 import org.apache.giraph.worker.WorkerProgress;
 
@@ -57,5 +58,9 @@ public class JobProgressTrackerClientNoOp implements JobProgressTrackerClient {
 
   @Override
   public void updateMasterProgress(MasterProgress masterProgress) {
+  }
+
+  @Override
+  public void sendMasterCounters(GiraphCountersThriftStruct giraphCounters) {
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
@@ -20,6 +20,7 @@ package org.apache.giraph.graph;
 
 import org.apache.giraph.conf.GiraphConfiguration;
 import org.apache.giraph.conf.IntConfOption;
+import org.apache.giraph.counters.GiraphCountersThriftStruct;
 import org.apache.giraph.job.ClientThriftServer;
 import org.apache.giraph.job.JobProgressTracker;
 import org.apache.giraph.master.MasterProgress;
@@ -192,6 +193,16 @@ public class RetryableJobProgressTrackerClient
       @Override
       public void run() {
         jobProgressTracker.updateMasterProgress(masterProgress);
+      }
+    }, numRetries);
+  }
+
+  @Override
+  public void sendMasterCounters(GiraphCountersThriftStruct giraphCounters) {
+    executeWithRetry(new Runnable() {
+      @Override
+      public void run() {
+        jobProgressTracker.sendMasterCounters(giraphCounters);
       }
     }, numRetries);
   }

--- a/giraph-core/src/main/java/org/apache/giraph/job/DefaultJobProgressTrackerService.java
+++ b/giraph-core/src/main/java/org/apache/giraph/job/DefaultJobProgressTrackerService.java
@@ -21,6 +21,8 @@ package org.apache.giraph.job;
 import org.apache.giraph.conf.GiraphConfiguration;
 import org.apache.giraph.conf.GiraphConstants;
 import org.apache.giraph.conf.IntConfOption;
+import org.apache.giraph.counters.CustomCounter;
+import org.apache.giraph.counters.GiraphCountersThriftStruct;
 import org.apache.giraph.master.MasterProgress;
 import org.apache.giraph.utils.ThreadUtils;
 import org.apache.giraph.worker.WorkerProgress;
@@ -28,6 +30,8 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -244,6 +248,18 @@ public class DefaultJobProgressTrackerService
   @Override
   public void updateMasterProgress(MasterProgress masterProgress) {
     this.masterProgress.set(masterProgress);
+  }
+
+  @Override
+  public void sendMasterCounters(GiraphCountersThriftStruct giraphCounters) {
+    if (LOG.isInfoEnabled()) {
+      List<CustomCounter> counterList = giraphCounters.getCounters();
+      Collections.sort(counterList);
+      for (CustomCounter customCounter : counterList) {
+        LOG.info(String.format("%s: %s: %d%n", customCounter.getGroupName(),
+              customCounter.getCounterName(), customCounter.getValue()));
+      }
+    }
   }
 
   @Override

--- a/giraph-core/src/main/java/org/apache/giraph/job/JobProgressTracker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/job/JobProgressTracker.java
@@ -21,6 +21,7 @@ package org.apache.giraph.job;
 import com.facebook.swift.service.ThriftMethod;
 import com.facebook.swift.service.ThriftService;
 
+import org.apache.giraph.counters.GiraphCountersThriftStruct;
 import org.apache.giraph.master.MasterProgress;
 import org.apache.giraph.worker.WorkerProgress;
 
@@ -78,5 +79,14 @@ public interface JobProgressTracker {
    */
   @ThriftMethod
   void updateMasterProgress(MasterProgress masterProgress);
+
+  /**
+   * Master should call this method after all supersteps are finished,
+   * and send the aggregated counters to the job client
+   *
+   * @param giraphCounters Giraph-based counters
+   */
+  @ThriftMethod
+  void sendMasterCounters(GiraphCountersThriftStruct giraphCounters);
 }
 

--- a/giraph-core/src/main/java/org/apache/giraph/master/MasterThread.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/MasterThread.java
@@ -191,6 +191,7 @@ public class MasterThread<I extends WritableComparable, V extends Writable,
         GiraphTimers.getInstance().getTotalMs().
           increment(System.currentTimeMillis() - initializeMillis);
       }
+      bspServiceMaster.addGiraphTimersAndSendCounters();
       bspServiceMaster.postApplication();
       // CHECKSTYLE: stop IllegalCatchCheck
     } catch (Exception e) {

--- a/giraph-core/src/main/java/org/apache/giraph/master/input/MasterInputSplitsHandler.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/input/MasterInputSplitsHandler.java
@@ -34,8 +34,11 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -56,6 +59,9 @@ public class MasterInputSplitsHandler {
       new StrConfOption("giraph.master.input.doneFractionsToStoreInCounters",
           "0.99,1", "Store in counters timestamps when we finished reading " +
           "these fractions of input");
+  /** Map of counter group and names */
+  private static Map<String, Set<String>> COUNTER_GROUP_AND_NAMES =
+          new HashMap<>();
 
   /** Whether to use locality information */
   private final boolean useLocality;
@@ -225,7 +231,16 @@ public class MasterInputSplitsHandler {
    */
   public static Counter getSplitFractionDoneTimestampCounter(
       InputType inputType, double fraction, Mapper.Context context) {
-    return context.getCounter(inputType.name() + " input",
-        String.format("%.2f%% done time (ms)", fraction * 100));
+    String groupName = inputType.name() + " input";
+    String counterName = String.format("%.2f%% done time (ms)", fraction * 100);
+    Set<String> counters = COUNTER_GROUP_AND_NAMES.getOrDefault(
+            groupName, new HashSet<>());
+    counters.add(counterName);
+    COUNTER_GROUP_AND_NAMES.put(groupName, counters);
+    return context.getCounter(groupName, counterName);
+  }
+
+  public static Map<String, Set<String>> getCounterGroupAndNames() {
+    return COUNTER_GROUP_AND_NAMES;
   }
 }

--- a/giraph-core/src/main/java/org/apache/giraph/master/input/MasterInputSplitsHandler.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/input/MasterInputSplitsHandler.java
@@ -34,11 +34,11 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -61,7 +61,7 @@ public class MasterInputSplitsHandler {
           "these fractions of input");
   /** Map of counter group and names */
   private static Map<String, Set<String>> COUNTER_GROUP_AND_NAMES =
-          new HashMap<>();
+          new ConcurrentHashMap<>();
 
   /** Whether to use locality information */
   private final boolean useLocality;

--- a/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
@@ -1290,7 +1290,7 @@ else[HADOOP_NON_SECURE]*/
               CreateMode.PERSISTENT,
               true);
     } catch (KeeperException.NodeExistsException e) {
-      LOG.warn("finishSuperstep: finished worker path " +
+      LOG.warn("storeCountersInZookeeper: finished worker path " +
               finishedWorkerPath + " already exists!");
     } catch (KeeperException e) {
       LOG.warn("Creating " + finishedWorkerPath +

--- a/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
+++ b/giraph-core/src/main/java/org/apache/giraph/worker/BspServiceWorker.java
@@ -1282,6 +1282,8 @@ else[HADOOP_NON_SECURE]*/
     String finishedWorkerPath =
             getWorkerCountersFinishedPath(getApplicationAttempt(), superStep) +
                     "/" + workerInfo.getHostnameId();
+    LOG.info(String.format("Writing counters to zookeeper for superstep: %d",
+            superStep));
     try {
       getZkExt().createExt(finishedWorkerPath,
               jsonCounters.toString().getBytes(

--- a/giraph-core/src/main/java/org/apache/giraph/yarn/GiraphYarnTask.java
+++ b/giraph-core/src/main/java/org/apache/giraph/yarn/GiraphYarnTask.java
@@ -91,6 +91,7 @@ public class GiraphYarnTask<I extends WritableComparable, V extends Writable,
       graphTaskManager.setup(null); // defaults GTM to "assume fatjar mode"
       graphTaskManager.execute();
       graphTaskManager.cleanup();
+      graphTaskManager.sendWorkerCountersAndFinishCleanup();
     } catch (InterruptedException ie) {
       LOG.error("run() caught an unrecoverable InterruptedException.", ie);
     } catch (IOException ioe) {


### PR DESCRIPTION
Counter mechanism
Adds the mechanism to generate counters like gc-related metrics, file system metrics and job-specific counters. 
The counters need to be defined in CustomCounters, when storing in the job context.
The workers write these counters to the zookeeper after each superstep, and the master aggregates them from all the workers, and sends these aggregated counters to the job client using a thrift client.
 
In case of a failure, the master would have the aggregated counters until the previous superstep, and these partial counters will be sent using the thrift client.