### PR TITLE
Make JobProgressTrackeClient implementation configurable

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -49,8 +49,10 @@ import org.apache.giraph.graph.Computation;
 import org.apache.giraph.graph.DefaultVertex;
 import org.apache.giraph.graph.DefaultVertexResolver;
 import org.apache.giraph.graph.DefaultVertexValueCombiner;
+import org.apache.giraph.graph.JobProgressTrackerClient;
 import org.apache.giraph.graph.Language;
 import org.apache.giraph.graph.MapperObserver;
+import org.apache.giraph.graph.RetryableJobProgressTrackerClient;
 import org.apache.giraph.graph.Vertex;
 import org.apache.giraph.graph.VertexResolver;
 import org.apache.giraph.graph.VertexValueCombiner;
@@ -1200,6 +1202,13 @@ public interface GiraphConstants {
   BooleanConfOption TRACK_JOB_PROGRESS_ON_CLIENT =
       new BooleanConfOption("giraph.trackJobProgressOnClient", false,
           "Whether to track job progress on client or not");
+
+  /** Class to use as the job progress client */
+  ClassConfOption<JobProgressTrackerClient> JOB_PROGRESS_TRACKER_CLIENT_CLASS =
+      ClassConfOption.create("giraph.jobProgressTrackerClientClass",
+        RetryableJobProgressTrackerClient.class,
+          JobProgressTrackerClient.class,
+          "Class to use to make calls to the job progress tracker service");
 
   /** Class to use to track job progress on client */
   ClassConfOption<JobProgressTrackerService> JOB_PROGRESS_TRACKER_CLASS =

--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -1211,8 +1211,9 @@ public interface GiraphConstants {
           "Class to use to make calls to the job progress tracker service");
 
   /** Class to use to track job progress on client */
-  ClassConfOption<JobProgressTrackerService> JOB_PROGRESS_TRACKER_CLASS =
-      ClassConfOption.create("giraph.jobProgressTrackerClass",
+  ClassConfOption<JobProgressTrackerService>
+    JOB_PROGRESS_TRACKER_SERVICE_CLASS =
+      ClassConfOption.create("giraph.jobProgressTrackerServiceClass",
           DefaultJobProgressTrackerService.class,
           JobProgressTrackerService.class,
           "Class to use to track job progress on client");

--- a/giraph-core/src/main/java/org/apache/giraph/graph/JobProgressTrackerClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/JobProgressTrackerClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.giraph.graph;
 
+import org.apache.giraph.conf.GiraphConfiguration;
 import org.apache.giraph.job.JobProgressTracker;
 
 import java.io.IOException;
@@ -30,4 +31,11 @@ import java.io.IOException;
 public interface JobProgressTrackerClient extends JobProgressTracker {
   /** Close the connections if any */
   void cleanup() throws IOException;
+
+  /**
+   * Initialize the client.
+   * @param conf Job configuration
+   * @throws Exception
+   */
+  void init(GiraphConfiguration conf) throws Exception;
 }

--- a/giraph-core/src/main/java/org/apache/giraph/graph/JobProgressTrackerClientNoOp.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/JobProgressTrackerClientNoOp.java
@@ -18,6 +18,7 @@
 
 package org.apache.giraph.graph;
 
+import org.apache.giraph.conf.GiraphConfiguration;
 import org.apache.giraph.master.MasterProgress;
 import org.apache.giraph.worker.WorkerProgress;
 
@@ -28,6 +29,10 @@ import org.apache.giraph.worker.WorkerProgress;
 public class JobProgressTrackerClientNoOp implements JobProgressTrackerClient {
   @Override
   public void cleanup() {
+  }
+
+  @Override
+  public void init(GiraphConfiguration conf) {
   }
 
   @Override

--- a/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
@@ -63,7 +63,7 @@ public class RetryableJobProgressTrackerClient
   private static final Logger LOG =
       Logger.getLogger(RetryableJobProgressTrackerClient.class);
   /** Configuration */
-  private final GiraphConfiguration conf;
+  private GiraphConfiguration conf;
   /** Thrift client manager to use to connect to job progress tracker */
   private ThriftClientManager clientManager;
   /** Job progress tracker */
@@ -80,6 +80,14 @@ public class RetryableJobProgressTrackerClient
    */
   public RetryableJobProgressTrackerClient(GiraphConfiguration conf) throws
       ExecutionException, InterruptedException {
+    this.conf = conf;
+    numRetries = RETRYABLE_JOB_PROGRESS_CLIENT_NUM_RETRIES.get(conf);
+    retryWaitMsec = RETRYABLE_JOB_PROGRESS_CLIENT_RETRY_WAIT_MS.get(conf);
+    resetConnection();
+  }
+
+  @Override
+  public void init(GiraphConfiguration conf) throws Exception {
     this.conf = conf;
     numRetries = RETRYABLE_JOB_PROGRESS_CLIENT_NUM_RETRIES.get(conf);
     retryWaitMsec = RETRYABLE_JOB_PROGRESS_CLIENT_RETRY_WAIT_MS.get(conf);

--- a/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/RetryableJobProgressTrackerClient.java
@@ -74,6 +74,13 @@ public class RetryableJobProgressTrackerClient
   private int retryWaitMsec;
 
   /**
+   * Default constructor. Typically once an instance is created it should be
+   * initialized by calling {@link #init(GiraphConfiguration)}.
+   */
+  public RetryableJobProgressTrackerClient() {
+  }
+
+  /**
    * Constructor
    *
    * @param conf Giraph configuration

--- a/giraph-core/src/main/java/org/apache/giraph/job/DefaultJobProgressTrackerService.java
+++ b/giraph-core/src/main/java/org/apache/giraph/job/DefaultJobProgressTrackerService.java
@@ -270,7 +270,7 @@ public class DefaultJobProgressTrackerService
     }
 
     JobProgressTrackerService jobProgressTrackerService =
-        GiraphConstants.JOB_PROGRESS_TRACKER_CLASS.newInstance(conf);
+        GiraphConstants.JOB_PROGRESS_TRACKER_SERVICE_CLASS.newInstance(conf);
     jobProgressTrackerService.init(conf, jobObserver);
     return jobProgressTrackerService;
   }


### PR DESCRIPTION
Currently, the implementation of the JobProgressTrackerClient that is used to make thrift calls to the JobProgressTrackerService is not configurable. For instance, some environments may require using a different thrift client underneath.

https://issues.apache.org/jira/browse/GIRAPH-1226

Tests:
- mvn -Phadoop_facebook clean install
- Ran a number of jobs with the default and with a custom client