### PR TITLE
Upgrade Netty to 4.1.36

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.giraph.comm.netty;
 
+import io.netty.handler.flush.FlushConsolidationHandler;
 import org.apache.giraph.comm.flow_control.CreditBasedFlowControl;
 import org.apache.giraph.comm.flow_control.FlowControl;
 import org.apache.giraph.comm.flow_control.NoOpFlowControl;
@@ -245,9 +246,9 @@ public class NettyClient {
    *                         terminate job.
    */
   public NettyClient(Mapper<?, ?, ?, ?>.Context context,
-                     final ImmutableClassesGiraphConfiguration conf,
-                     TaskInfo myTaskInfo,
-                     final Thread.UncaughtExceptionHandler exceptionHandler) {
+    final ImmutableClassesGiraphConfiguration conf, TaskInfo myTaskInfo,
+    final Thread.UncaughtExceptionHandler exceptionHandler) {
+
     this.context = context;
     this.myTaskInfo = myTaskInfo;
     this.channelsPerServer = GiraphConstants.CHANNELS_PER_SERVER.get(conf);
@@ -272,16 +273,13 @@ public class NettyClient {
     }
 
     networkRequestsResentForTimeout =
-        new GiraphHadoopCounter(context.getCounter(
-            NETTY_COUNTERS_GROUP,
+        new GiraphHadoopCounter(context.getCounter(NETTY_COUNTERS_GROUP,
             NETWORK_REQUESTS_RESENT_FOR_TIMEOUT_NAME));
     networkRequestsResentForChannelFailure =
-        new GiraphHadoopCounter(context.getCounter(
-            NETTY_COUNTERS_GROUP,
+        new GiraphHadoopCounter(context.getCounter(NETTY_COUNTERS_GROUP,
             NETWORK_REQUESTS_RESENT_FOR_CHANNEL_FAILURE_NAME));
     networkRequestsResentForConnectionFailure =
-      new GiraphHadoopCounter(context.getCounter(
-        NETTY_COUNTERS_GROUP,
+      new GiraphHadoopCounter(context.getCounter(NETTY_COUNTERS_GROUP,
         NETWORK_REQUESTS_RESENT_FOR_CONNECTION_FAILURE_NAME));
 
     maxRequestMilliseconds = MAX_REQUEST_MILLISECONDS.get(conf);
@@ -335,6 +333,10 @@ public class NettyClient {
             if (conf.authenticate()) {
               LOG.info("Using Netty with authentication.");
 
+              PipelineUtils.addLastWithExecutorCheck("flushConsolidation",
+                new FlushConsolidationHandler(FlushConsolidationHandler
+                  .DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES, true),
+                handlerToUseExecutionGroup, executionGroup, ch);
               // Our pipeline starts with just byteCounter, and then we use
               // addLast() to incrementally add pipeline elements, so that we
               // can name them for identification for removal or replacement
@@ -386,6 +388,10 @@ public class NettyClient {
             } else {
               LOG.info("Using Netty without authentication.");
 /*end[HADOOP_NON_SECURE]*/
+              PipelineUtils.addLastWithExecutorCheck("flushConsolidation",
+                new FlushConsolidationHandler(FlushConsolidationHandler
+                    .DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES, true),
+                handlerToUseExecutionGroup, executionGroup, ch);
               PipelineUtils.addLastWithExecutorCheck("clientInboundByteCounter",
                   inboundByteCounter, handlerToUseExecutionGroup,
                   executionGroup, ch);
@@ -839,13 +845,17 @@ public class NettyClient {
   }
 
   /**
-   * Write request to a channel for its destination
+   * Write request to a channel for its destination.
+   *
+   * Whenever we write to the channel, we also call flush, but we have added a
+   * {@link FlushConsolidationHandler} in the pipeline, which batches the
+   * flushes.
    *
    * @param requestInfo Request info
    */
   private void writeRequestToChannel(RequestInfo requestInfo) {
     Channel channel = getNextChannel(requestInfo.getDestinationAddress());
-    ChannelFuture writeFuture = channel.write(requestInfo.getRequest());
+    ChannelFuture writeFuture = channel.writeAndFlush(requestInfo.getRequest());
     requestInfo.setWriteFuture(writeFuture);
     writeFuture.addListener(logErrorListener);
   }

--- a/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyServer.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyServer.java
@@ -18,6 +18,7 @@
 
 package org.apache.giraph.comm.netty;
 
+import io.netty.handler.flush.FlushConsolidationHandler;
 import org.apache.giraph.comm.flow_control.FlowControl;
 /*if_not[HADOOP_NON_SECURE]*/
 import org.apache.giraph.comm.netty.handler.AuthorizeServerHandler;
@@ -257,6 +258,10 @@ public class NettyServer {
           // pipeline components SaslServerHandler and ResponseEncoder are
           // removed, leaving the pipeline the same as in the non-authenticated
           // configuration except for the presence of the Authorize component.
+          PipelineUtils.addLastWithExecutorCheck("flushConsolidation",
+            new FlushConsolidationHandler(FlushConsolidationHandler
+              .DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES, true),
+            handlerToUseExecutionGroup, executionGroup, ch);
           PipelineUtils.addLastWithExecutorCheck("serverInboundByteCounter",
               inByteCounter, handlerToUseExecutionGroup, executionGroup, ch);
           if (conf.doCompression()) {
@@ -307,6 +312,10 @@ public class NettyServer {
                   ctx.fireChannelActive();
                 }
               });
+          PipelineUtils.addLastWithExecutorCheck("flushConsolidation",
+            new FlushConsolidationHandler(FlushConsolidationHandler
+              .DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES, true),
+            handlerToUseExecutionGroup, executionGroup, ch);
           PipelineUtils.addLastWithExecutorCheck("serverInboundByteCounter",
               inByteCounter, handlerToUseExecutionGroup, executionGroup, ch);
           if (conf.doCompression()) {

--- a/giraph-core/src/main/java/org/apache/giraph/conf/FacebookConfiguration.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/FacebookConfiguration.java
@@ -132,8 +132,6 @@ public class FacebookConfiguration implements BulkConfigurator {
     StaticFlowControl.MAX_NUMBER_OF_OPEN_REQUESTS.setIfUnset(conf, 100);
     // Pooled allocator in netty is faster
     GiraphConstants.NETTY_USE_POOLED_ALLOCATOR.setIfUnset(conf, true);
-    // Turning off auto read is faster
-    GiraphConstants.NETTY_AUTO_READ.setIfUnset(conf, false);
 
     // Synchronize full gc calls across workers
     MemoryObserver.USE_MEMORY_OBSERVER.setIfUnset(conf, true);

--- a/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/GiraphConstants.java
@@ -653,15 +653,6 @@ public interface GiraphConstants {
       new StrConfOption("giraph.nettyCompressionAlgorithm", "",
           "Which compression algorithm to use in netty");
 
-  /**
-   * Whether netty should pro-actively read requests and feed them to its
-   * processing pipeline
-   */
-  BooleanConfOption NETTY_AUTO_READ =
-      new BooleanConfOption("giraph.nettyAutoRead", true,
-          "Whether netty should pro-actively read requests and feed them to " +
-              "its processing pipeline");
-
   /** Max resolve address attempts */
   IntConfOption MAX_RESOLVE_ADDRESS_ATTEMPTS =
       new IntConfOption("giraph.maxResolveAddressAttempts", 5,

--- a/giraph-core/src/main/java/org/apache/giraph/conf/ImmutableClassesGiraphConfiguration.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/ImmutableClassesGiraphConfiguration.java
@@ -1355,7 +1355,7 @@ public class ImmutableClassesGiraphConfiguration<I extends WritableComparable,
   public ByteToMessageDecoder getNettyCompressionDecoder() {
     switch (GiraphConstants.NETTY_COMPRESSION_ALGORITHM.get(this)) {
     case "SNAPPY":
-      return new SnappyFramedDecoder(true);
+      return new SnappyFramedDecoder();
     case "INFLATE":
       return new JdkZlibDecoder();
     default:

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@ under the License.
     <dep.log4j.version>1.2.17</dep.log4j.version>
     <dep.mockito.version>1.9.5</dep.mockito.version>
     <!-- note: old version of netty is required by hadoop_facebook for tests to succeed -->
-    <dep.netty.version>4.0.14.Final</dep.netty.version>
+    <dep.netty.version>4.1.36.Final</dep.netty.version>
     <dep.oldnetty.version>3.2.2.Final</dep.oldnetty.version>
     <dep.objenesis.version>2.2</dep.objenesis.version>
     <dep.openhft-compiler.version>2.2.1</dep.openhft-compiler.version>


### PR DESCRIPTION
- Upgrades Netty to 4.1.36
- Auto-reading used to be an option. Experiments showed that disabling it not reliable with the new version, so we'll keep it permanently enabled.

https://issues.apache.org/jira/browse/GIRAPH-1228

Tests:
- Unit tests
- Ran a number of large jobs and performance is similar.