### PR TITLE
Fix guava imports

### DIFF
--- a/giraph-block-app/pom.xml
+++ b/giraph-block-app/pom.xml
@@ -103,10 +103,6 @@ under the License.
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.python</groupId>
-      <artifactId>jython</artifactId>
-    </dependency>
-    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency>

--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockMasterLogic.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/internal/BlockMasterLogic.java
@@ -36,7 +36,7 @@ import org.apache.giraph.conf.GiraphConfiguration;
 import org.apache.giraph.function.Consumer;
 import org.apache.giraph.writable.tuple.IntLongWritable;
 import org.apache.log4j.Logger;
-import org.python.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 
 /**
  * Block execution logic on master, iterating over Pieces of the

--- a/giraph-block-app/src/test/java/org/apache/giraph/block_app/framework/BlockExecutionTest.java
+++ b/giraph-block-app/src/test/java/org/apache/giraph/block_app/framework/BlockExecutionTest.java
@@ -46,7 +46,7 @@ import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.junit.Assert;
 import org.junit.Test;
-import org.python.google.common.collect.Iterables;
+import com.google.common.collect.Iterables;
 
 /**
  * Test of barebones of Blocks Framework.

--- a/giraph-core/src/main/java/org/apache/giraph/conf/DefaultMessageClasses.java
+++ b/giraph-core/src/main/java/org/apache/giraph/conf/DefaultMessageClasses.java
@@ -29,7 +29,7 @@ import org.apache.giraph.utils.ReflectionUtils;
 import org.apache.giraph.utils.WritableUtils;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
-import org.python.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 
 /**
  * Default implementation of MessageClasses

--- a/giraph-core/src/main/java/org/apache/giraph/graph/GraphTaskManager.java
+++ b/giraph-core/src/main/java/org/apache/giraph/graph/GraphTaskManager.java
@@ -21,8 +21,6 @@ package org.apache.giraph.graph;
 import java.io.IOException;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
-import java.net.URL;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;

--- a/giraph-core/src/main/java/org/apache/giraph/master/SuperstepClasses.java
+++ b/giraph-core/src/main/java/org/apache/giraph/master/SuperstepClasses.java
@@ -37,7 +37,7 @@ import org.apache.giraph.utils.WritableUtils;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.log4j.Logger;
-import org.python.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 
 /**
  * Holds Computation and MessageCombiner class.

--- a/giraph-core/src/main/java/org/apache/giraph/reducers/impl/PairReduce.java
+++ b/giraph-core/src/main/java/org/apache/giraph/reducers/impl/PairReduce.java
@@ -26,7 +26,7 @@ import org.apache.giraph.reducers.ReduceOperation;
 import org.apache.giraph.utils.WritableUtils;
 import org.apache.giraph.writable.tuple.PairWritable;
 import org.apache.hadoop.io.Writable;
-import org.python.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 
 /**
  * Combines two individual reducers, to create a single reducer of pairs that

--- a/giraph-core/src/main/java/org/apache/giraph/worker/AllWorkersInfo.java
+++ b/giraph-core/src/main/java/org/apache/giraph/worker/AllWorkersInfo.java
@@ -20,7 +20,7 @@ package org.apache.giraph.worker;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.python.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 


### PR DESCRIPTION
https://issues.apache.org/jira/projects/GIRAPH/issues/GIRAPH-1231

There are a number of imports throughout the code for guava utilities that use "import org.python.google..." rather than "com.google...". Giraph already has a dependency on guava and these imports only work due to the dependency on jython, which embeds a shaded guava.

Test:
mvn clean test