### PR TITLE
Upgrade findbugs maven plugin

### DIFF
--- a/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/output/BlockOutputHandle.java
+++ b/giraph-block-app/src/main/java/org/apache/giraph/block_app/framework/output/BlockOutputHandle.java
@@ -51,11 +51,11 @@ public class BlockOutputHandle implements BlockOutputApi {
       Progressable hadoopProgressable) {
     outputDescMap = BlockOutputFormat.createInitAndCheckOutputDescsMap(
         conf, jobIdentifier);
-    for (String confOption : outputDescMap.keySet()) {
-      outputDescMap.get(confOption).preWriting();
-      freeWriters.put(confOption,
+    for (Map.Entry<String, BlockOutputDesc> entry : outputDescMap.entrySet()) {
+      entry.getValue().preWriting();
+      freeWriters.put(entry.getKey(),
           new ConcurrentLinkedQueue<BlockOutputWriter>());
-      occupiedWriters.put(confOption,
+      occupiedWriters.put(entry.getKey(),
           new ConcurrentLinkedQueue<BlockOutputWriter>());
     }
     initialize(conf, hadoopProgressable);

--- a/pom.xml
+++ b/pom.xml
@@ -776,7 +776,7 @@ under the License.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.0.4</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <findbugsXmlOutput>false</findbugsXmlOutput>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GIRAPH-1245

- Upgrades the findbugs maven plugin
- Refactors a small piece of code for which the findbugs plugin finds an error.

This should fix the CI build.

Tests:
mvn clean verify -Phadoop_facebook
mvn clean verify