### PR TITLE
Upgrade findbugs for giraph-core

### DIFF
--- a/giraph-core/pom.xml
+++ b/giraph-core/pom.xml
@@ -141,7 +141,6 @@ under the License.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.0</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <findbugsXmlOutput>false</findbugsXmlOutput>

--- a/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyClient.java
+++ b/giraph-core/src/main/java/org/apache/giraph/comm/netty/NettyClient.java
@@ -646,11 +646,13 @@ public class NettyClient {
   public void authenticate() {
     LOG.info("authenticate: NettyClient starting authentication with " +
         "servers.");
-    for (InetSocketAddress address: addressChannelMap.keySet()) {
+    for (Map.Entry<InetSocketAddress, ChannelRotater> entry :
+      addressChannelMap.entrySet()) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("authenticate: Authenticating with address:" + address);
+        LOG.debug("authenticate: Authenticating with address:" +
+          entry.getKey());
       }
-      ChannelRotater channelRotater = addressChannelMap.get(address);
+      ChannelRotater channelRotater = entry.getValue();
       for (Channel channel: channelRotater.getChannels()) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("authenticate: Authenticating with server on channel: " +

--- a/giraph-core/src/main/java/org/apache/giraph/mapping/LongByteMappingStore.java
+++ b/giraph-core/src/main/java/org/apache/giraph/mapping/LongByteMappingStore.java
@@ -21,6 +21,7 @@ package org.apache.giraph.mapping;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -131,8 +132,8 @@ public class LongByteMappingStore
   @Override
   public void postFilling() {
     // not thread-safe
-    for (Long id : concurrentIdToBytes.keySet()) {
-      idToBytes.put(id, concurrentIdToBytes.get(id));
+    for (Map.Entry<Long, byte[]> entry : concurrentIdToBytes.entrySet()) {
+      idToBytes.put(entry.getKey(), entry.getValue());
     }
     concurrentIdToBytes.clear();
     concurrentIdToBytes = null;

--- a/giraph-core/src/main/java/org/apache/giraph/ooc/persistence/LocalDiskDataAccessor.java
+++ b/giraph-core/src/main/java/org/apache/giraph/ooc/persistence/LocalDiskDataAccessor.java
@@ -109,6 +109,8 @@ public class LocalDiskDataAccessor implements OutOfCoreDataAccessor {
   public void initialize() { }
 
   @Override
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+    "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
   public void shutdown() {
     for (String path : basePaths) {
       File file = new File(path);

--- a/giraph-core/src/main/java/org/apache/giraph/utils/AnnotationUtils.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/AnnotationUtils.java
@@ -207,6 +207,8 @@ public class AnnotationUtils {
      * @param directory Directory from which we are adding files
      * @param files List we add files to
      */
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+    "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private void addAllClassFiles(File directory, List<File> files) {
       for (File file : directory.listFiles()) {
         if (file.isDirectory()) {

--- a/giraph-core/src/main/java/org/apache/giraph/utils/UnsafeArrayReads.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/UnsafeArrayReads.java
@@ -34,6 +34,8 @@ import static org.apache.giraph.utils.ByteUtils.SIZE_OF_DOUBLE;
  * Byte array input stream that uses Unsafe methods to deserialize
  * much faster
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings(
+  "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
 public class UnsafeArrayReads extends UnsafeReads {
   /** Access to the unsafe class */
   private static final sun.misc.Unsafe UNSAFE;

--- a/giraph-core/src/main/java/org/apache/giraph/utils/UnsafeReads.java
+++ b/giraph-core/src/main/java/org/apache/giraph/utils/UnsafeReads.java
@@ -27,6 +27,8 @@ import java.io.UTFDataFormatException;
  * Byte array input stream that uses Unsafe methods to deserialize
  * much faster
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings(
+  "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
 public abstract class UnsafeReads extends Input implements ExtendedDataInput {
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/projects/GIRAPH/issues/GIRAPH-1245

giraph-core/pom.xml was manually overriding the version of findbugs. As a result the CI build still failed. Removing the override so that it uses the findbugs version of the parent pom.xml. Along with this, i fixed some "bugs" the new version finds.

Test:
mvn clean verify -Phadoop_facebook
mvn clean verify