### PR TITLE
Increase SNAPSHOT version

### DIFF
--- a/giraph-block-app-8/pom.xml
+++ b/giraph-block-app-8/pom.xml
@@ -24,7 +24,7 @@ under the License.
   <parent>
     <groupId>org.apache.giraph</groupId>
     <artifactId>giraph-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>giraph-block-app-8</artifactId>
   <packaging>jar</packaging>

--- a/giraph-block-app/pom.xml
+++ b/giraph-block-app/pom.xml
@@ -24,7 +24,7 @@ under the License.
   <parent>
     <groupId>org.apache.giraph</groupId>
     <artifactId>giraph-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>giraph-block-app</artifactId>
   <packaging>jar</packaging>

--- a/giraph-core/pom.xml
+++ b/giraph-core/pom.xml
@@ -24,7 +24,7 @@ under the License.
   <parent>
     <groupId>org.apache.giraph</groupId>
     <artifactId>giraph-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>giraph-core</artifactId>
   <packaging>jar</packaging>

--- a/giraph-debugger/pom.xml
+++ b/giraph-debugger/pom.xml
@@ -26,7 +26,7 @@ under the License.
   <parent>
     <groupId>org.apache.giraph</groupId>
     <artifactId>giraph-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>giraph-debugger</artifactId>
   <packaging>jar</packaging>

--- a/giraph-dist/pom.xml
+++ b/giraph-dist/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.giraph</groupId>
     <artifactId>giraph-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>giraph-dist</artifactId>

--- a/giraph-examples/pom.xml
+++ b/giraph-examples/pom.xml
@@ -24,7 +24,7 @@ under the License.
   <parent>
     <groupId>org.apache.giraph</groupId>
     <artifactId>giraph-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>giraph-examples</artifactId>
   <packaging>jar</packaging>
@@ -429,7 +429,7 @@ under the License.
     <dependency>
       <groupId>org.apache.giraph</groupId>
       <artifactId>giraph-core</artifactId>
-      <version>1.3.0-SNAPSHOT</version>
+      <version>1.4.0-SNAPSHOT</version>
       <type>test-jar</type>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ under the License.
   <groupId>org.apache.giraph</groupId>
   <artifactId>giraph-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
 
   <name>Apache Giraph Parent</name>
   <url>http://giraph.apache.org/</url>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GIRAPH-1247
We've released 1.3.0. Increasing SNAPSHOT version.

Tests:
mvn clean install
mvn clean -Phadoop_facebook install