### PR TITLE
Website changes for new release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ under the License.
   <groupId>org.apache.giraph</groupId>
   <artifactId>giraph-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
 
   <name>Apache Giraph Parent</name>
   <url>http://giraph.apache.org/</url>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -32,11 +32,12 @@ under the License.
       <p><i>Apache Giraph</i> is an iterative graph processing system built for high scalability. For example, it is currently used at Facebook to analyze the social graph formed by users and their connections. Giraph originated as the open-source counterpart to <i>Pregel</i>, the graph processing architecture developed at Google and described in a 2010 <a href="http://dl.acm.org/citation.cfm?id=1807184">paper</a>. Both systems are inspired by the <a href="http://en.wikipedia.org/wiki/Bulk_synchronous_parallel">Bulk Synchronous Parallel</a> model of distributed computation introduced by Leslie Valiant. Giraph adds several features beyond the basic Pregel model, including master computation, sharded aggregators, edge-oriented input, out-of-core computation, and more. With a steady development cycle and a growing community of users worldwide, Giraph is a natural choice for unleashing the potential of structured datasets at a massive scale. To learn more, consult the <i>User Docs</i> section above.</p>
 
       <subsection name="Download">
-        <p>Official releases of Giraph may be downloaded from an <a href="http://www.apache.org/dyn/closer.cgi/giraph/">Apache mirror</a>. Pre-built packages will soon be available through Apache's Maven repositories, making it easier to include Giraph in your projects.</p>        
+        <p>Official releases of Giraph may be downloaded from an <a href="http://www.apache.org/dyn/closer.cgi/giraph/">Apache mirror</a>. Pre-built packages are also available through Apache's Maven repositories, making it easier to include Giraph in your projects.</p>        
       </subsection>
 
       <subsection name="News">
         <ul>
+          <li><strong>June 11, 2020: Giraph 1.3.0 is now released!</strong> Please pick up a copy <a href="http://www.apache.org/dyn/closer.cgi/giraph/giraph-1.3.0">here</a>.</li>
           <li><strong>Oct 20, 2016: Giraph 1.2.0 is now released!</strong> Please pick up a copy <a href="http://www.apache.org/dyn/closer.cgi/giraph/giraph-1.2.0">here</a>.</li>
           <li><strong>Oct 28, 2015: Practical Graph Analytics with Apache Giraph is now available from Apress.</strong> More details in our books section <a href="literature.html">here</a>.</li>
           <li><strong>Nov 19, 2014: Giraph 1.1.0 is now released!</strong> Please pick up a copy <a href="http://www.apache.org/dyn/closer.cgi/giraph/giraph-1.1.0">here</a>.</li>

--- a/src/site/xdoc/releases.xml
+++ b/src/site/xdoc/releases.xml
@@ -33,15 +33,10 @@ under the License.
 <p>
 Here are our stable releases of Giraph.</p>
 <ul>
+  <li><strong>1.3.0</strong> - Download <a href="http://www.apache.org/dyn/closer.cgi/giraph/giraph-1.3.0">here</a>.</li>
   <li><strong>1.2.0</strong> - Download <a href="http://www.apache.org/dyn/closer.cgi/giraph/giraph-1.2.0">here</a>.</li>
   <li><strong>1.1.0</strong> - Download <a href="http://www.apache.org/dyn/closer.cgi/giraph/giraph-1.1.0">here</a>.</li>
   <li><strong>1.0.0</strong> - Download <a href="http://www.apache.org/dyn/closer.cgi/giraph/giraph-1.0.0">here</a>.</li>
-</ul>
-
-<p>
-Giraph is also part of <b>grafos.ml</b>, which is the Real-Time graph processing framework, developed at Telefonica.</p>
-<ul>
-  <li><strong>0.3.2</strong> - Download <a href="http://grafos.ml/Download.html">here</a>.</li>
 </ul>
 
 

--- a/src/site/xdoc/releasing_giraph.xml
+++ b/src/site/xdoc/releasing_giraph.xml
@@ -72,7 +72,8 @@ mvn clean install -Phadoop_2
 
       </li>
       <li>Finally make files available in dist SVN:
-          <tt>svn checkout https://dist.apache.org/repos/dist/dev/giraph/</tt>
+          <tt>svn checkout https://dist.apache.org/repos/dist/dev/giraph/</tt>, and 
+          <tt>svn checkout https://dist.apache.org/repos/dist/release/giraph/</tt>
           Make sure that the content there looks ok (try to build and run Giraph just from those tarballs).
       </li>
       <li>


### PR DESCRIPTION
https://issues.apache.org/jira/projects/GIRAPH/issues/GIRAPH-1246

Updating to site to point to the new release, plus some other changes.

Tests:
mvn -Phadoop_2 clean site -DskipTests

Updated http://giraph.apache.org/