### PR TITLE
Update the dependency version of hadoop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1121,7 +1121,7 @@ under the License.
         <module>giraph-dist</module>
       </modules>
        <properties>
-         <hadoop.version>2.5.1</hadoop.version>
+         <hadoop.version>2.9.2</hadoop.version>
          <!-- TODO: add these checks eventually -->
          <project.enforcer.skip>true</project.enforcer.skip>
          <giraph.maven.dependency.plugin.skip>true</giraph.maven.dependency.plugin.skip>


### PR DESCRIPTION
The current latest version of hadoop 2 is 2.9.2. Could you consider upgrading the giraph dependencies to that version? This requires modifying the version number in the pom file.

Test:
    first execute `mvn -DskipTests -Phadoop_2 clean package `
    After that run shortest path on hadoop 2.9.2 with giraph example package