### PR TITLE
GIRAPH-1252. bump up jython version to 2.7.2-standalone

### DIFF
--- a/giraph-core/pom.xml
+++ b/giraph-core/pom.xml
@@ -543,7 +543,7 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.python</groupId>
-      <artifactId>jython</artifactId>
+      <artifactId>jython-standalone</artifactId>
     </dependency>
     <dependency>
       <groupId>com.esotericsoftware</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@ under the License.
     <dep.jetty.version>6.1.26</dep.jetty.version>
     <dep.json.version>20160810</dep.json.version>
     <dep.junit.version>4.11</dep.junit.version>
-    <dep.jython.version>2.5.3</dep.jython.version>
+    <dep.jython-standalone.version>2.7.2</dep.jython-standalone.version>
     <dep.kryo.version>4.0.0</dep.kryo.version>
     <dep.reflectasm.version>1.11.3</dep.reflectasm.version>
     <dep.kryo-serializers.version>0.42</dep.kryo-serializers.version>
@@ -483,7 +483,7 @@ under the License.
               </dependency>
               <dependency>
                 <groupId>org.python</groupId>
-                <artifactId>jython</artifactId>
+                <artifactId>jython-standalone</artifactId>
               </dependency>
               <dependency>
                 <groupId>org.apache.hive</groupId>
@@ -1456,8 +1456,8 @@ under the License.
       </dependency>
       <dependency>
         <groupId>org.python</groupId>
-        <artifactId>jython</artifactId>
-        <version>${dep.jython.version}</version>
+        <artifactId>jython-standalone</artifactId>
+        <version>${dep.jython-standalone.version}</version>
       </dependency>
       <dependency>
         <groupId>com.esotericsoftware</groupId>


### PR DESCRIPTION
Hello, this PR is to address https://issues.apache.org/jira/browse/GIRAPH-1252, which will bump up Giraph's jython version to 2.7.2-standalone.