### PR TITLE
GIRAPH-1253: Fix vertex value reinitialized to initialValue 

### DIFF
--- a/giraph-block-app-8/src/main/java/org/apache/giraph/block_app/library/pagerank/PageRankBlockUtils.java
+++ b/giraph-block-app-8/src/main/java/org/apache/giraph/block_app/library/pagerank/PageRankBlockUtils.java
@@ -44,7 +44,7 @@ public class PageRankBlockUtils {
       SupplierFromVertex<I, V, DoubleWritable, DoubleWritable> valueGetter,
       GiraphConfiguration conf) {
     return new SequenceBlock(
-        new PageRankInitializeAndNormalizeEdgesPiece<>(valueSetter, conf),
+        new PageRankInitializeAndNormalizeEdgesPiece<>(),
         pagerank(valueSetter, valueGetter,
             (vertex, edgeValue) -> edgeValue.get(), conf));
   }

--- a/giraph-block-app-8/src/main/java/org/apache/giraph/block_app/library/pagerank/PageRankInitializeAndNormalizeEdgesPiece.java
+++ b/giraph-block-app-8/src/main/java/org/apache/giraph/block_app/library/pagerank/PageRankInitializeAndNormalizeEdgesPiece.java
@@ -24,11 +24,9 @@ import org.apache.giraph.block_app.framework.piece.Piece;
 import org.apache.giraph.block_app.framework.piece.interfaces.VertexReceiver;
 import org.apache.giraph.block_app.framework.piece.interfaces.VertexSender;
 import org.apache.giraph.combiner.NullMessageCombiner;
-import org.apache.giraph.conf.GiraphConfiguration;
 import org.apache.giraph.conf.ImmutableClassesGiraphConfiguration;
 import org.apache.giraph.edge.Edge;
 import org.apache.giraph.edge.MutableEdge;
-import org.apache.giraph.function.vertex.ConsumerWithVertex;
 import org.apache.hadoop.io.DoubleWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Writable;
@@ -45,15 +43,7 @@ public class PageRankInitializeAndNormalizeEdgesPiece<
     extends Piece<I, V, DoubleWritable, NullWritable, Object> {
   /** Consumer which sets pagerank value in vertex */
 
-  /**
-   * Constructor
-   *
-   * @param valueSetter Consumer which sets pagerank value in vertex
-   * @param conf        Configuration
-   */
-  public PageRankInitializeAndNormalizeEdgesPiece(
-      ConsumerWithVertex<I, V, DoubleWritable, DoubleWritable> valueSetter,
-      GiraphConfiguration conf) {
+  public PageRankInitializeAndNormalizeEdgesPiece() {
   }
 
   @Override

--- a/giraph-block-app-8/src/main/java/org/apache/giraph/block_app/library/pagerank/PageRankInitializeAndNormalizeEdgesPiece.java
+++ b/giraph-block-app-8/src/main/java/org/apache/giraph/block_app/library/pagerank/PageRankInitializeAndNormalizeEdgesPiece.java
@@ -44,10 +44,6 @@ public class PageRankInitializeAndNormalizeEdgesPiece<
     I extends WritableComparable, V extends Writable>
     extends Piece<I, V, DoubleWritable, NullWritable, Object> {
   /** Consumer which sets pagerank value in vertex */
-  private final ConsumerWithVertex<I, V, DoubleWritable, DoubleWritable>
-      valueSetter;
-  /** Default initial value pagerank value */
-  private final DoubleWritable initialValue;
 
   /**
    * Constructor
@@ -58,8 +54,6 @@ public class PageRankInitializeAndNormalizeEdgesPiece<
   public PageRankInitializeAndNormalizeEdgesPiece(
       ConsumerWithVertex<I, V, DoubleWritable, DoubleWritable> valueSetter,
       GiraphConfiguration conf) {
-    this.valueSetter = valueSetter;
-    initialValue = new DoubleWritable(PageRankSettings.getInitialValue(conf));
   }
 
   @Override
@@ -87,8 +81,7 @@ public class PageRankInitializeAndNormalizeEdgesPiece<
   public VertexReceiver<I, V, DoubleWritable, NullWritable> getVertexReceiver(
       BlockWorkerReceiveApi<I> workerApi, Object executionStage) {
     return (vertex, messages) -> {
-      // Set initial pagerank value on all vertices
-      valueSetter.apply(vertex, initialValue);
+      // Do nothing
     };
   }
 

--- a/giraph-block-app-8/src/test/java/org/apache/giraph/block_app/library/pagerank/PageRankTest.java
+++ b/giraph-block-app-8/src/test/java/org/apache/giraph/block_app/library/pagerank/PageRankTest.java
@@ -202,7 +202,7 @@ public class PageRankTest {
       TestGraph<LongWritable, DoubleWritable, DoubleWritable> graph) {
     Vertex<LongWritable, DoubleWritable, DoubleWritable> v = graph.getConf().createVertex();
     v.setConf(graph.getConf());
-    v.initialize(new LongWritable(id), new DoubleWritable(), newEdges(edges, weights));
+    v.initialize(new LongWritable(id), new DoubleWritable(1), newEdges(edges, weights));
     graph.addVertex(v);
   }
 


### PR DESCRIPTION
Summary:
1. removing reinitilizing of vertex value to initial value from first step of weighted pagerank

Test Plan:
ran a set of test jobs to check for correctness